### PR TITLE
Docs(design-system): CSS 스타일 수정 및 스토리북 데이터 업데이트

### DIFF
--- a/packages/design-system/src/components/artist-card/artist-card.css.ts
+++ b/packages/design-system/src/components/artist-card/artist-card.css.ts
@@ -49,9 +49,15 @@ export const artistName = recipe({
   },
   variants: {
     size: {
-      sm: [themeVars.fontStyles.body4_m_13],
-      md: [themeVars.fontStyles.body2_m_15],
-      lg: [themeVars.fontStyles.body3_m_14],
+      sm: {
+        ...themeVars.fontStyles.body4_m_13,
+      },
+      md: {
+        ...themeVars.fontStyles.body2_m_15,
+      },
+      lg: {
+        ...themeVars.fontStyles.body3_m_14,
+      },
     },
   },
 });

--- a/packages/design-system/src/components/artist-card/artist-card.stories.tsx
+++ b/packages/design-system/src/components/artist-card/artist-card.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof ArtistCard> = {
   },
   decorators: [
     (Story) => (
-      <div style={{ width: '375px' }}>
+      <div style={{ width: '100px' }}>
         <Story />
       </div>
     ),
@@ -24,26 +24,29 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     artistId: '1',
-    title: '데이식스',
-    imageSrc: 'https://dummyimage.com/80X80',
-    size: 'lg',
+    title: '한로로',
+    imageSrc:
+      'https://i.scdn.co/image/ab6761610000f1786a50f39b95ce98a0e6bf5b21',
+    size: 'md',
   },
 };
 
 export const Sm: Story = {
   args: {
-    artistId: '1',
-    title: '데이식스',
-    imageSrc: 'https://dummyimage.com/80X80',
+    artistId: '2',
+    title: 'Coldplay',
+    imageSrc:
+      'https://i.scdn.co/image/ab6761610000f1781ba8fc5f5c73e7e9313cc6eb',
     size: 'sm',
   },
 };
 
 export const Md: Story = {
   args: {
-    artistId: '1',
+    artistId: '3',
     title: '데이식스',
-    imageSrc: 'https://dummyimage.com/80X80',
+    imageSrc:
+      'https://i.scdn.co/image/ab6761610000f17810e83b0ca558533d0f3c376c',
     size: 'md',
   },
 };

--- a/packages/design-system/src/components/festival-card/festival-card.stories.tsx
+++ b/packages/design-system/src/components/festival-card/festival-card.stories.tsx
@@ -21,24 +21,39 @@ type Story = StoryObj<typeof FestivalCard>;
 
 export const Default: Story = {
   args: {
-    title: '2024 위버스 콘 페스티벌',
-    imageSrc: 'https://dummyimage.com/100x142',
+    title: '오로라 내한 공연',
+    imageSrc: 'https://i.imgur.com/DwH8XUo.png',
   },
+  render: (args) => (
+    <div style={{ width: '10rem', height: '14rem' }}>
+      <FestivalCard {...args} />
+    </div>
+  ),
 };
 
 export const Selectable: Story = {
   args: {
-    title: '2024 위버스 콘 페스티벌',
-    imageSrc: 'https://dummyimage.com/100x142',
+    title: '오로라 내한 공연',
+    imageSrc: 'https://i.imgur.com/DwH8XUo.png',
     selectable: true,
   },
+  render: (args) => (
+    <div style={{ width: '10rem', height: '14rem' }}>
+      <FestivalCard {...args} />
+    </div>
+  ),
 };
 
 export const Preselected: Story = {
   args: {
-    title: '2024 위버스 콘 페스티벌',
-    imageSrc: 'https://dummyimage.com/100x142',
+    title: '오로라 내한 공연',
+    imageSrc: 'https://i.imgur.com/DwH8XUo.png',
     selectable: true,
     isSelected: true,
   },
+  render: (args) => (
+    <div style={{ width: '10rem', height: '14rem' }}>
+      <FestivalCard {...args} />
+    </div>
+  ),
 };

--- a/packages/design-system/src/components/floating-button/floating-button.css.ts
+++ b/packages/design-system/src/components/floating-button/floating-button.css.ts
@@ -3,7 +3,7 @@ import { themeVars } from '../../styles';
 
 export const floatingButtonVariants = recipe({
   base: {
-    position: 'sticky',
+    position: 'absolute',
     width: '4rem',
     height: '4rem',
     display: 'flex',

--- a/packages/design-system/src/components/floating-button/floating-button.stories.tsx
+++ b/packages/design-system/src/components/floating-button/floating-button.stories.tsx
@@ -14,4 +14,29 @@ const meta: Meta<typeof FloatingButton> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100vw',
+        height: '100vh',
+        background: '#f0f0f0',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          position: 'relative',
+          width: '430px',
+          height: '100%',
+          background: '#ffffff',
+        }}
+      >
+        <FloatingButton />,
+      </div>
+    </div>
+  ),
+};

--- a/packages/design-system/src/components/floating-button/floating-button.stories.tsx
+++ b/packages/design-system/src/components/floating-button/floating-button.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import FloatingButton from './floating-button';
-
 const meta: Meta<typeof FloatingButton> = {
   title: 'Common/FloatingButton',
   component: FloatingButton,

--- a/packages/design-system/src/components/like-button/like-button.stories.tsx
+++ b/packages/design-system/src/components/like-button/like-button.stories.tsx
@@ -22,10 +22,20 @@ export const Liked: Story = {
   args: {
     isFavorite: true,
   },
+  render: (args) => (
+    <div style={{ width: '2.5rem', height: '2.5rem' }}>
+      <LikeButton {...args} />
+    </div>
+  ),
 };
 
 export const Unliked: Story = {
   args: {
     isFavorite: false,
   },
+  render: (args) => (
+    <div style={{ width: '2.5rem', height: '2.5rem' }}>
+      <LikeButton {...args} />
+    </div>
+  ),
 };

--- a/packages/design-system/src/components/performance-carousel/performance-carousel.stories.tsx
+++ b/packages/design-system/src/components/performance-carousel/performance-carousel.stories.tsx
@@ -1,12 +1,13 @@
 import type { Meta } from '@storybook/react';
 import PerformanceCarousel from './performance-carousel';
+import { PerformData } from './performance-carousel';
 
-const MOCK_PERFORM_DATA = [
+const MOCK_PERFORM_DATA: PerformData[] = [
   {
     typeId: 1,
     type: 'concert',
     title: '오아시스 내한공연',
-    subTitle: 'LIVE NATION PRESENTS COLDPLAY',
+    subtitle: 'LIVE NATION PRESENTS COLDPLAY',
     performanceAt: '2025.10.21',
     posterUrl: 'https://dummyimage.com/197x262',
   },
@@ -14,47 +15,7 @@ const MOCK_PERFORM_DATA = [
     typeId: 2,
     type: 'festival',
     title: '오아시스 내한공연',
-    subTitle: '라이브 네이션 프레젠트 콜드플레이',
-    performanceAt: '2025.10.21',
-    posterUrl: 'https://dummyimage.com/197x262',
-  },
-  {
-    typeId: 3,
-    type: 'festival',
-    title: '오아시스 내한공연3',
-    subTitle: 'LIVE NATION PRESENTS COLDPLAY',
-    performanceAt: '2025.10.21',
-    posterUrl: 'https://dummyimage.com/197x262',
-  },
-  {
-    typeId: 4,
-    type: 'festival',
-    title: '오아시스 내한공연4',
-    subTitle: '콜드플레이 내한 공연', // subTitle 수정
-    performanceAt: '2025.10.21',
-    posterUrl: 'https://dummyimage.com/197x262',
-  },
-  {
-    typeId: 5,
-    type: 'festival',
-    title: '오아시스 내한공연5',
-    subTitle: 'LIVE NATION PRESENTS COLDPLAY',
-    performanceAt: '2025.10.21',
-    posterUrl: 'https://dummyimage.com/197x262',
-  },
-  {
-    typeId: 6,
-    type: 'festival',
-    title: '오아시스 내한공연6',
-    subTitle: 'LIVE NATION PRESENTS COLDPLAY',
-    performanceAt: '2025.10.21',
-    posterUrl: 'https://dummyimage.com/197x262',
-  },
-  {
-    typeId: 7,
-    type: 'festival',
-    title: '오아시스 내한공연7',
-    subTitle: '콜드플레이와 함께하는 축제',
+    subtitle: '라이브 네이션 프레젠트 콜드플레이',
     performanceAt: '2025.10.21',
     posterUrl: 'https://dummyimage.com/197x262',
   },

--- a/packages/design-system/src/components/performance-carousel/performance-carousel.stories.tsx
+++ b/packages/design-system/src/components/performance-carousel/performance-carousel.stories.tsx
@@ -5,19 +5,19 @@ import { PerformData } from './performance-carousel';
 const MOCK_PERFORM_DATA: PerformData[] = [
   {
     typeId: 1,
-    type: 'CONCERT',
-    title: '오아시스 내한공연',
-    subtitle: 'LIVE NATION PRESENTS COLDPLAY',
-    performanceAt: '2025.10.21',
-    posterUrl: 'https://dummyimage.com/197x262',
+    type: 'FESTIVAL',
+    title: '러브 썸 페스티벌',
+    subtitle: 'LOVESOME',
+    performanceAt: '2025.04.27',
+    posterUrl: 'https://i.imgur.com/b89Kzzd.png',
   },
   {
     typeId: 2,
     type: 'FESTIVAL',
-    title: '오아시스 내한공연',
-    subtitle: '라이브 네이션 프레젠트 콜드플레이',
-    performanceAt: '2025.10.21',
-    posterUrl: 'https://dummyimage.com/197x262',
+    title: '뷰티풀 민트 라이프',
+    subtitle: 'Beautiful Mint Life 2025',
+    performanceAt: '2025.05.11',
+    posterUrl: 'https://i.imgur.com/9yX1b3P.png',
   },
 ];
 

--- a/packages/design-system/src/components/performance-carousel/performance-carousel.stories.tsx
+++ b/packages/design-system/src/components/performance-carousel/performance-carousel.stories.tsx
@@ -5,7 +5,7 @@ import { PerformData } from './performance-carousel';
 const MOCK_PERFORM_DATA: PerformData[] = [
   {
     typeId: 1,
-    type: 'concert',
+    type: 'CONCERT',
     title: '오아시스 내한공연',
     subtitle: 'LIVE NATION PRESENTS COLDPLAY',
     performanceAt: '2025.10.21',
@@ -13,7 +13,7 @@ const MOCK_PERFORM_DATA: PerformData[] = [
   },
   {
     typeId: 2,
-    type: 'festival',
+    type: 'FESTIVAL',
     title: '오아시스 내한공연',
     subtitle: '라이브 네이션 프레젠트 콜드플레이',
     performanceAt: '2025.10.21',

--- a/packages/design-system/src/components/performance-carousel/performance-carousel.tsx
+++ b/packages/design-system/src/components/performance-carousel/performance-carousel.tsx
@@ -8,7 +8,7 @@ import { useNavigate } from 'react-router-dom';
 
 export interface PerformData {
   typeId: number;
-  type: 'concert' | 'festival' | 'artist';
+  type: 'CONCERT' | 'FESTIVAL' | 'ARTIST';
   title: string;
   subtitle?: string | null;
   performanceAt: string;

--- a/packages/design-system/src/components/performance-carousel/performance-carousel.tsx
+++ b/packages/design-system/src/components/performance-carousel/performance-carousel.tsx
@@ -6,9 +6,9 @@ import './dots.css';
 import './performance-carousel.css';
 import { useNavigate } from 'react-router-dom';
 
-interface PerformData {
+export interface PerformData {
   typeId: number;
-  type: 'FESTIVAL' | 'CONCERT' | 'ARTIST';
+  type: 'concert' | 'festival' | 'artist';
   title: string;
   subtitle?: string | null;
   performanceAt: string;


### PR DESCRIPTION
## 📌 Summary

* #304 

## 📚 Tasks

디자인 시스템 내에서  `Card` 의 mock 데이터를 실제 이미지 파일로 변경합니다


## 👀 To Reviewer

Card 컴포넌트의 샘플 데이터를 실제 이미지 url 로 변경해두었습니다. UI를 스토리북 내에서 판단하기에 해당 방법이 더 적합하다고 생각했어요.

일단 이러한 방법이 옳은지에 대해서도 잘 모르겠어요.. 레퍼런스가 많이 없어서 추가적으로 고민되는 부분은  
![image](https://github.com/user-attachments/assets/67ed3905-78e8-47dd-bcf0-a8273c9a79fb)

위 사진과 같이 현재 `Festival Card` 도 마찬가지로 dummy data 로 설정되어있어요. 스토리북에서 mock 데이터를 활용하는 이유는 서버와의 의존성을 낮추기 위함인데 `Card` 컴포넌트의 경우 현재 사용하는 `Spotify` API 에서 가져오는 url 이라 무관할 것 같지만,

Festival Card에 사용되는 이미지 url 의 경우 서버 자체 S3 버킷에서 제공하는 파일 url 이라 dummy data를 수정해야 할지 고민이에요... 

제가 생각해본 방법은 아래와 같아요

1. mock data 자체를 정적 파일로 저장해둔다. ex ) public/assets 등등..
2. 현상 유지한다.

2번의 경우 
```
Card 컴포넌트의 샘플 데이터를 실제 이미지 url 로 변경해두었습니다. UI를 스토리북 내에서 판단하기에 해당 방법이 더 적합하다고 생각했어요.
```
이 의견에도 동의하지 않는다고 생각할 수 있어요 의견 부탁드립니다~

💦반대가 많을 시 브랜치 삭제하고 튑니다. 브삭튀 🛵💦💦💦💦

## 📸 Screenshot

### Before
![image](https://github.com/user-attachments/assets/c2db36cf-dca3-4195-a864-609367f543c8)

### After 

![image](https://github.com/user-attachments/assets/cff5e4a3-d444-4b02-9c04-902cf5eaa1f7)

---

### before 
![image](https://github.com/user-attachments/assets/dec9a2d7-43a9-463a-addc-11dbf95fd230)

### after

![image](https://github.com/user-attachments/assets/00812a45-8117-4d94-9c32-3885a6db0306)


### before
<img width="585" alt="image" src="https://github.com/user-attachments/assets/7acf5443-aa73-4b86-a3ed-dcf9cda1ca6c" />

### After
<img width="585" alt="image" src="https://github.com/user-attachments/assets/af3f7ab1-010d-46f3-a6d3-3601b50296ea" />


### before

![image](https://github.com/user-attachments/assets/aec025cb-a3e2-423f-aa07-7bdf00e1fdc5)

### after

![image](https://github.com/user-attachments/assets/998d7586-e54f-4018-b4a3-56522921720f)

* 좋아요 버튼 스토리북내에서 사이즈가 너무 작은 것 같아 실제 confeti.co.kr 에 사용되는 사이즈와 거의 유사하게 조정하였습니다

### before

![image](https://github.com/user-attachments/assets/dcf4cd62-a43c-4ce1-a519-49e1b7313a42)


### after 

![image](https://github.com/user-attachments/assets/d01a4165-709f-42f3-ac95-aeba9ec51797)
