### PR TITLE
Refactor(design-system): display 디자인 토큰 리팩토링

### DIFF
--- a/apps/client/src/pages/my/components/artist/no-artist-section.css.ts
+++ b/apps/client/src/pages/my/components/artist/no-artist-section.css.ts
@@ -2,7 +2,7 @@ import { themeVars } from '@confeti/design-system/styles';
 import { style } from '@vanilla-extract/css';
 
 export const wrapper = style({
-  ...themeVars.display.flexCenter,
+  ...themeVars.display.flexJustifyAlignCenter,
   flexDirection: 'column',
   padding: '1.6rem 0',
   gap: '2rem',

--- a/apps/client/src/pages/my/components/performance/no-performance-section.css.ts
+++ b/apps/client/src/pages/my/components/performance/no-performance-section.css.ts
@@ -2,7 +2,7 @@ import { themeVars } from '@confeti/design-system/styles';
 import { style } from '@vanilla-extract/css';
 
 export const wrapper = style({
-  ...themeVars.display.flexCenter,
+  ...themeVars.display.flexJustifyAlignCenter,
   ...themeVars.fontStyles.body3_m_14,
   color: themeVars.color.gray500,
   padding: '6.4rem',

--- a/apps/client/src/pages/performance/components/artist/artist-card.css.ts
+++ b/apps/client/src/pages/performance/components/artist/artist-card.css.ts
@@ -2,7 +2,7 @@ import { style } from '@vanilla-extract/css';
 import { themeVars } from '@confeti/design-system/styles';
 
 export const artist = style({
-  ...themeVars.display.flexColumnCenter,
+  ...themeVars.display.flexColumnAlignTextCenter,
   gap: '1.2rem',
 });
 

--- a/apps/client/src/pages/performance/components/button/more-button.css.ts
+++ b/apps/client/src/pages/performance/components/button/more-button.css.ts
@@ -4,7 +4,7 @@ import { themeVars } from '@confeti/design-system/styles';
 
 export const button = recipe({
   base: {
-    ...themeVars.display.flexCenter,
+    ...themeVars.display.flexJustifyAlignCenter,
     width: '100%',
     height: '4.4rem',
     backgroundColor: themeVars.color.white,

--- a/apps/client/src/pages/performance/components/poster/poster.css.ts
+++ b/apps/client/src/pages/performance/components/poster/poster.css.ts
@@ -2,7 +2,7 @@ import { themeVars } from '@confeti/design-system/styles';
 import { style } from '@vanilla-extract/css';
 
 export const container = style({
-  ...themeVars.display.flexCenter,
+  ...themeVars.display.flexJustifyAlignCenter,
   width: '100%',
   height: '100%',
 });

--- a/apps/client/src/pages/search/components/artist-info.css.ts
+++ b/apps/client/src/pages/search/components/artist-info.css.ts
@@ -20,7 +20,9 @@ export const image = style({
 });
 
 export const textSection = style({
-  ...themeVars.display.flexColumnLeft,
+  ...themeVars.display.flexColumn,
+  justifyContent: 'center',
+  textAlign: 'left',
   flex: 1,
   gap: '1.05rem',
 });

--- a/apps/client/src/pages/search/components/artist-not-found.css.ts
+++ b/apps/client/src/pages/search/components/artist-not-found.css.ts
@@ -2,7 +2,7 @@ import { style } from '@vanilla-extract/css';
 import { themeVars } from '@confeti/design-system/styles';
 
 export const container = style({
-  ...themeVars.display.flexColumnCenter,
+  ...themeVars.display.flexColumnAlignTextCenter,
   position: 'absolute',
   top: '48%',
   left: '50%',

--- a/apps/client/src/pages/search/components/performance-section.css.ts
+++ b/apps/client/src/pages/search/components/performance-section.css.ts
@@ -6,7 +6,7 @@ export const section = style({
 });
 
 export const emptyPerformanceSection = style({
-  ...themeVars.display.flexCenter,
+  ...themeVars.display.flexJustifyAlignCenter,
   ...themeVars.fontStyles.body3_m_14,
   height: '23rem',
   fontSize: '1.4rem',

--- a/apps/client/src/pages/time-table/components/booth-open-box/booth-open-box.css.ts
+++ b/apps/client/src/pages/time-table/components/booth-open-box/booth-open-box.css.ts
@@ -3,7 +3,7 @@ import { themeVars } from '@confeti/design-system/styles';
 
 export const wrapper = style({
   ...themeVars.fontStyles.body3_m_14,
-  ...themeVars.display.flexCenter,
+  ...themeVars.display.flexJustifyAlignCenter,
   position: 'absolute',
   top: '0.7rem',
   right: '0',

--- a/apps/client/src/pages/time-table/components/calender/calender.css.ts
+++ b/apps/client/src/pages/time-table/components/calender/calender.css.ts
@@ -24,7 +24,7 @@ export const dateSection = style({
 });
 
 export const dateItems = style({
-  ...themeVars.display.flexColumnCenter,
+  ...themeVars.display.flexColumnAlignTextCenter,
   width: '3rem',
   height: '5.5rem',
   gap: '0.6rem',
@@ -32,7 +32,7 @@ export const dateItems = style({
 
 export const dayNum = recipe({
   base: {
-    ...themeVars.display.flexCenter,
+    ...themeVars.display.flexJustifyAlignCenter,
     width: '3rem',
     height: '3rem',
     borderRadius: '1.5rem',
@@ -62,7 +62,7 @@ export const dayNum = recipe({
 
 export const dayKo = recipe({
   base: {
-    ...themeVars.display.flexCenter,
+    ...themeVars.display.flexJustifyAlignCenter,
     background: 'transparent',
   },
   variants: {

--- a/apps/client/src/pages/time-table/components/edit/edit-floating-button.css.ts
+++ b/apps/client/src/pages/time-table/components/edit/edit-floating-button.css.ts
@@ -18,7 +18,7 @@ const fadeOutText = keyframes({
 });
 
 export const box = style({
-  ...themeVars.display.flexCenter,
+  ...themeVars.display.flexJustifyAlignCenter,
   flexDirection: 'column',
   alignItems: 'flex-start',
   padding: '1rem 5.3rem 0.9rem 1.6rem',
@@ -44,14 +44,14 @@ export const boxAtBottom = style({
 });
 
 export const boxButton = style({
-  ...themeVars.display.flexCenter,
+  ...themeVars.display.flexJustifyAlignCenter,
   padding: '0.8rem 0',
   cursor: 'pointer',
 });
 
 export const buttonVariants = recipe({
   base: {
-    ...themeVars.display.flexCenter,
+    ...themeVars.display.flexJustifyAlignCenter,
     height: '5rem',
     position: 'fixed',
     right: '2rem',

--- a/apps/client/src/pages/time-table/components/empty/empty-festival-section.css.ts
+++ b/apps/client/src/pages/time-table/components/empty/empty-festival-section.css.ts
@@ -2,7 +2,7 @@ import { style } from '@vanilla-extract/css';
 import { themeVars } from '@confeti/design-system/styles';
 
 export const container = style({
-  ...themeVars.display.flexColumnCenter,
+  ...themeVars.display.flexColumnAlignTextCenter,
   position: 'absolute',
   top: '50%',
   left: '50%',
@@ -12,7 +12,7 @@ export const container = style({
 });
 
 export const iconDescriptionWrapper = style({
-  ...themeVars.display.flexColumnCenter,
+  ...themeVars.display.flexColumnAlignTextCenter,
   gap: '2rem',
 });
 

--- a/apps/client/src/pages/time-table/components/info/info-button.css.ts
+++ b/apps/client/src/pages/time-table/components/info/info-button.css.ts
@@ -12,7 +12,10 @@ const shake = keyframes({
 
 export const containerVariants = recipe({
   base: {
-    ...themeVars.display.flexColumnStart,
+    ...themeVars.display.flexColumn,
+    justifyContent: 'center',
+    alignItems: 'center',
+    alignSelf: 'stretch',
     background: themeVars.color.white,
   },
   variants: {
@@ -64,7 +67,7 @@ export const ItemsVariants = recipe({
 
 export const ImageVariants = recipe({
   base: {
-    ...themeVars.display.flexCenter,
+    ...themeVars.display.flexJustifyAlignCenter,
     border: themeVars.border.gray400,
     background: themeVars.color.white,
     flexShrink: '0',

--- a/apps/client/src/pages/time-table/components/stage/stage.css.ts
+++ b/apps/client/src/pages/time-table/components/stage/stage.css.ts
@@ -3,7 +3,7 @@ import { themeVars } from '@confeti/design-system/styles';
 
 export const wrapper = style({
   ...themeVars.fontStyles.caption_r_10,
-  ...themeVars.display.flexCenter,
+  ...themeVars.display.flexJustifyAlignCenter,
   textAlign: 'center',
   width: '100%',
   height: '4rem',

--- a/apps/client/src/pages/time-table/components/time-table-item/time-table-item.css.ts
+++ b/apps/client/src/pages/time-table/components/time-table-item/time-table-item.css.ts
@@ -3,7 +3,7 @@ import { themeVars } from '@confeti/design-system/styles';
 
 export const itemsWrapper = recipe({
   base: {
-    ...themeVars.display.flexColumnCenter,
+    ...themeVars.display.flexColumnAlignTextCenter,
     justifyContent: 'center',
     position: 'absolute',
     top: 'calc( 0.75rem + var(--top) )',

--- a/apps/client/src/shared/pages/auth/require-login-section.css.ts
+++ b/apps/client/src/shared/pages/auth/require-login-section.css.ts
@@ -2,7 +2,7 @@ import { style } from '@vanilla-extract/css';
 import { themeVars } from '@confeti/design-system/styles';
 
 export const container = style({
-  ...themeVars.display.flexColumnCenter,
+  ...themeVars.display.flexColumnAlignTextCenter,
   position: 'absolute',
   top: '55%',
   left: '50%',

--- a/apps/client/src/shared/pages/error/error.css.ts
+++ b/apps/client/src/shared/pages/error/error.css.ts
@@ -2,7 +2,7 @@ import { style } from '@vanilla-extract/css';
 import { themeVars } from '@confeti/design-system/styles';
 
 export const container = style({
-  ...themeVars.display.flexCenter,
+  ...themeVars.display.flexJustifyAlignCenter,
   flexDirection: 'column',
   height: 'calc(100dvh - 14rem)',
   gap: '2rem',

--- a/apps/client/src/shared/pages/loading/loading.css.ts
+++ b/apps/client/src/shared/pages/loading/loading.css.ts
@@ -2,6 +2,6 @@ import { style } from '@vanilla-extract/css';
 import { themeVars } from '@confeti/design-system/styles';
 
 export const loadingSection = style({
-  ...themeVars.display.flexCenter,
+  ...themeVars.display.flexJustifyAlignCenter,
   height: 'calc(100dvh - 5rem)',
 });

--- a/packages/design-system/src/components/artist-card/artist-card.css.ts
+++ b/packages/design-system/src/components/artist-card/artist-card.css.ts
@@ -4,7 +4,7 @@ import { style } from '@vanilla-extract/css';
 
 export const artistCardVariants = recipe({
   base: {
-    ...themeVars.display.flexColumnCenter,
+    ...themeVars.display.flexColumnAlignTextCenter,
     position: 'relative',
     gap: '1.2rem',
     cursor: 'pointer',

--- a/packages/design-system/src/components/button/button.css.ts
+++ b/packages/design-system/src/components/button/button.css.ts
@@ -4,7 +4,7 @@ import { themeVars } from '../../styles';
 export const buttonVariants = recipe({
   base: {
     width: '100%',
-    ...themeVars.display.flexCenter,
+    ...themeVars.display.flexJustifyAlignCenter,
     gap: '0.8rem',
     borderRadius: '1rem',
     backgroundColor: themeVars.color.confeti_lime,

--- a/packages/design-system/src/components/search-bar/search-bar.css.ts
+++ b/packages/design-system/src/components/search-bar/search-bar.css.ts
@@ -3,7 +3,7 @@ import { recipe } from '@vanilla-extract/recipes';
 import { themeVars } from '../../styles';
 
 export const container = style({
-  ...themeVars.display.flexCenter,
+  ...themeVars.display.flexJustifyAlignCenter,
   padding: '0.8rem 2rem',
   width: '100%',
   gap: '0.8rem',

--- a/packages/design-system/src/components/ticketing-carousel/ticketing-carousel.css.ts
+++ b/packages/design-system/src/components/ticketing-carousel/ticketing-carousel.css.ts
@@ -30,7 +30,7 @@ export const active = style({
 });
 
 export const container = style({
-  ...themeVars.display.flexCenter,
+  ...themeVars.display.flexJustifyAlignCenter,
   background: themeVars.color.black_op,
   width: '100%',
   height: '100%',
@@ -48,7 +48,7 @@ export const info = style({
 });
 
 export const textSection = style({
-  ...themeVars.display.flexBetween,
+  ...themeVars.display.flexBetweenAlignCenter,
   flexDirection: 'column',
   alignItems: 'flex-start',
   alignSelf: 'stretch',
@@ -80,7 +80,7 @@ export const fixedWord = style({
 });
 
 export const infoBottom = style({
-  ...themeVars.display.flexBetween,
+  ...themeVars.display.flexBetweenAlignCenter,
   width: 'calc(100% - 4rem)',
   position: 'absolute',
   bottom: '1rem',

--- a/packages/design-system/src/components/toast/toast.css.ts
+++ b/packages/design-system/src/components/toast/toast.css.ts
@@ -19,7 +19,7 @@ export const icon = style({
 
 export const content = style({
   gap: '0.4rem',
-  ...themeVars.display.flexCenter,
+  ...themeVars.display.flexJustifyAlignCenter,
 });
 
 export const toast = recipe({
@@ -28,7 +28,7 @@ export const toast = recipe({
     width: '32.5rem',
     height: '5rem',
 
-    ...themeVars.display.flexCenter,
+    ...themeVars.display.flexJustifyAlignCenter,
     transform: 'translateX(-50%)',
     borderRadius: '5rem',
     backgroundColor: themeVars.color.gray800,

--- a/packages/design-system/src/styles/global.css.ts
+++ b/packages/design-system/src/styles/global.css.ts
@@ -12,7 +12,7 @@ globalStyle(':root', {
 
 /* HTML & Body Styles */
 globalStyle('html, body', {
-  ...themeVars.display.flexCenter,
+  ...themeVars.display.flexJustifyAlignCenter,
   position: 'relative', //floating button 추가로 인한 position 지정
   width: '100%',
   margin: '0',

--- a/packages/design-system/src/styles/tokens/display.ts
+++ b/packages/design-system/src/styles/tokens/display.ts
@@ -1,45 +1,27 @@
 export const display = {
-  flexCenter: {
+  flexJustifyAlignCenter: {
     display: 'flex',
-    alignItems: 'center',
     justifyContent: 'center',
+    alignItems: 'center',
   },
   flexAlignCenter: {
     display: 'flex',
     alignItems: 'center',
   },
-  flexCenterStretch: {
-    display: 'flex',
-    alignItems: 'center',
-    alignSelf: 'stretch',
-  },
   flexColumn: {
     display: 'flex',
     flexDirection: 'column',
   },
-  flexColumnCenter: {
+  flexColumnAlignTextCenter: {
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
     textAlign: 'center',
   },
-  flexColumnLeft: {
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'center',
-    textAlign: 'left',
-  },
-  flexBetween: {
+  flexBetweenAlignCenter: {
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
-    alignSelf: 'stretch',
-  },
-  flexColumnStart: {
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'center',
-    alignItems: 'flex-start',
     alignSelf: 'stretch',
   },
 } as const;

--- a/packages/design-system/src/styles/tokens/overlay.ts
+++ b/packages/design-system/src/styles/tokens/overlay.ts
@@ -9,7 +9,7 @@ export const overlay = {
     width: '100%',
     height: '100%',
     backgroundColor: color.black_op,
-    ...display.flexCenter,
+    ...display.flexJustifyAlignCenter,
     borderRadius: '1rem',
   },
 } as const;


### PR DESCRIPTION
## 📌 Summary

* #317 

## 📚 Tasks

display 관련 디자인 토큰에서 불필요한 속성들은 제거를 했어요 

그리고 추가로 토큰 네이밍도 변경했습니다

## 👀 To Reviewer

민하랑 얘기한 후에 

flexCenter
flexAlignCenter
flexColumn
flexColumnCenter 

이 `기존` 속성값들만 유지해도 충분히 거의 대부분의 상황에서 display 관련 속성이 커버가 된다고 판단했어요 나머지를 전부 삭제한 뒤에 between만 추가적으로 유지하였습니다.

그리고 네이밍이 기존에 너무 애매했던 것 같아서 아예 조금 길게 써버렸어요 

예를 들면

flexCenter 에도 alignItems : 'center' 속성이 있고
flexAlignCenter 에도 alignItems : 'center' 속성이 있는데 

flexCenter가 어떤게 Center 라는 거지? 항상 애매해서 

`flexJustifyAlignCenter` 라는 네이밍으로 `justifyContent` 와 `alignItems` 속성이 center 값을 가지고 있는 토큰이라는 것을 명시해보았어요

어차피 토큰은 자동완성이 되니깐 네이밍을 길게 가져가는 것이 더 나을 것 같아서 이런 방법을 사용했어요

기존 토큰 이름들이 변경되느라 변경사항이 좀 많은데 display 쪽 코드만 읽어주시면 돼요 


## 📸 Screenshot

![image](https://github.com/user-attachments/assets/9dd2dd8c-fa55-4a7d-bd93-b7a7f1fab458)

