### PR TITLE
Refactor(client): 타임테이블 픽셀 밀림 현상 개선

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -13,6 +13,7 @@
     "@tanstack/react-query": "^5.62.16",
     "@tanstack/react-query-devtools": "^5.62.16",
     "@vanilla-extract/css": "^1.17.0",
+    "@vanilla-extract/dynamic": "^2.1.2",
     "@vanilla-extract/recipes": "^0.5.5",
     "axios": "^1.7.9",
     "dom-to-image": "^2.6.0",

--- a/apps/client/src/pages/time-table/components/booth-open-box/booth-open-box.css.ts
+++ b/apps/client/src/pages/time-table/components/booth-open-box/booth-open-box.css.ts
@@ -8,7 +8,7 @@ export const wrapper = style({
   top: '0.7rem',
   right: '0',
   height: '4.5rem',
-  width: 'calc(100% - 3.1rem)',
+  width: 'calc(100% - 2.9rem)',
   color: themeVars.color.gray600,
   background: themeVars.color.gray200,
 });

--- a/apps/client/src/pages/time-table/components/time-cell/time-cell.css.ts
+++ b/apps/client/src/pages/time-table/components/time-cell/time-cell.css.ts
@@ -12,7 +12,7 @@ export const timeP = recipe({
   base: {
     ...themeVars.fontStyles.body5_r_12,
     padding: '0 0.4rem',
-    marginRight: '1.25rem',
+    marginRight: '0.7rem',
   },
   variants: {
     bold: {

--- a/apps/client/src/pages/time-table/components/time-table-board/time-table-board.tsx
+++ b/apps/client/src/pages/time-table/components/time-table-board/time-table-board.tsx
@@ -105,23 +105,22 @@ const TimeTableBoard = ({
             <p className={styles.minutesP}>{HALF_HOUR_TO_MINUTES}</p>
           </div>
         )}
-
-        <div className={styles.timeList}>
-          <p className={styles.timeP}>{END_HOUR}</p>
-          <hr className={styles.timeBar} />
-        </div>
-
-        {!isEditTimeTableMode && !isFestivalDeleteMode && (
-          <div className={styles.saveButtonWrapper}>
-            <Button
-              text="이미지 저장"
-              variant="add"
-              className={styles.saveButton}
-              onClick={downloadImage}
-            ></Button>
-          </div>
-        )}
       </div>
+      <div className={styles.timeList}>
+        <p className={styles.timeP}>{END_HOUR}</p>
+        <hr className={styles.timeBar} />
+      </div>
+
+      {!isEditTimeTableMode && !isFestivalDeleteMode && (
+        <div className={styles.saveButtonWrapper}>
+          <Button
+            text="이미지 저장"
+            variant="add"
+            className={styles.saveButton}
+            onClick={downloadImage}
+          ></Button>
+        </div>
+      )}
     </section>
   );
 };

--- a/apps/client/src/pages/time-table/components/time-table-item/time-table-item.css.ts
+++ b/apps/client/src/pages/time-table/components/time-table-item/time-table-item.css.ts
@@ -1,16 +1,21 @@
 import { recipe } from '@vanilla-extract/recipes';
+import { createVar } from '@vanilla-extract/css';
 import { themeVars } from '@confeti/design-system/styles';
+
+export const stageCount = createVar();
+export const stageOrder = createVar();
+export const topPosition = createVar();
+export const height = createVar();
 
 export const itemsWrapper = recipe({
   base: {
     ...themeVars.display.flexColumnCenter,
     justifyContent: 'center',
     position: 'absolute',
-    top: 'calc( 0.75rem + var(--top) )',
-    left: 'calc( 3.1rem + ((100% - 3.5rem) / var(--stage-count) * var(--stage-order)))',
-    height: 'var(--diff)',
-    width: 'calc((100% - 3.2rem) / var(--stage-count))',
-    // padding: '0.8rem 0rem',
+    top: `calc( 0.75rem + ${topPosition} )`,
+    left: `calc( 3.1rem + ((100% - 3.5rem) / ${stageCount} * ${stageOrder}))`,
+    height: height,
+    width: `calc((100% - 3.2rem) / ${stageCount})`,
     borderRadius: '2px',
     zIndex: themeVars.zIndex.timeTable.content,
     cursor: 'pointer',

--- a/apps/client/src/pages/time-table/components/time-table-item/time-table-item.css.ts
+++ b/apps/client/src/pages/time-table/components/time-table-item/time-table-item.css.ts
@@ -2,9 +2,9 @@ import { recipe } from '@vanilla-extract/recipes';
 import { createVar } from '@vanilla-extract/css';
 import { themeVars } from '@confeti/design-system/styles';
 
-export const stageCount = createVar();
-export const stageOrder = createVar();
-export const topPosition = createVar();
+export const left = createVar();
+export const width = createVar();
+export const top = createVar();
 export const height = createVar();
 
 export const itemsWrapper = recipe({
@@ -12,10 +12,10 @@ export const itemsWrapper = recipe({
     ...themeVars.display.flexColumnCenter,
     justifyContent: 'center',
     position: 'absolute',
-    top: `calc( 0.75rem + ${topPosition} )`,
-    left: `calc( 3.1rem + ((100% - 3.5rem) / ${stageCount} * ${stageOrder}))`,
+    top: top,
+    left: left,
     height: height,
-    width: `calc((100% - 3.2rem) / ${stageCount})`,
+    width: width,
     borderRadius: '2px',
     zIndex: themeVars.zIndex.timeTable.content,
     cursor: 'pointer',

--- a/apps/client/src/pages/time-table/components/time-table-item/time-table-item.tsx
+++ b/apps/client/src/pages/time-table/components/time-table-item/time-table-item.tsx
@@ -6,6 +6,7 @@ import {
   calcMinutesFromOpen,
 } from '@pages/time-table/utils';
 import * as styles from './time-table-item.css';
+import { assignInlineVars } from '@vanilla-extract/dynamic';
 
 interface ItemProps {
   artists: Artist[];
@@ -50,9 +51,6 @@ const TimeTableItem = ({
   );
   const { top, diff } = calcPosition(totalMin, minutesFromOpen);
 
-  //TODO: 추후 API 연결할때 필요한 prop, build 에러 방지를 위한 코드
-  userTimetableId;
-
   const handleSetSelectedBlock = () => {
     if (isEditTimeTableMode) {
       setSelectBlock((prev) => !prev);
@@ -60,16 +58,16 @@ const TimeTableItem = ({
     }
   };
 
+  const dynamicVars = assignInlineVars({
+    [styles.stageCount]: stageCount.toString(),
+    [styles.stageOrder]: (stageOrder - 1).toString(),
+    [styles.topPosition]: `${top}rem`,
+    [styles.height]: `${diff}rem`,
+  });
+
   return (
     <div
-      style={
-        {
-          '--stage-count': stageCount,
-          '--stage-order': stageOrder - 1,
-          '--diff': `${diff}rem`,
-          '--top': `${top}rem`,
-        } as React.CSSProperties
-      }
+      style={dynamicVars}
       className={styles.itemsWrapper({ isSelected: selectBlock })}
       onClick={handleSetSelectedBlock}
     >

--- a/apps/client/src/pages/time-table/components/time-table-item/time-table-item.tsx
+++ b/apps/client/src/pages/time-table/components/time-table-item/time-table-item.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
 import {
   parseTimeString,
-  calcPosition,
   calcTotalMinutes,
   calcMinutesFromOpen,
+  calcTotalFestivalMinutes,
 } from '@pages/time-table/utils';
+
 import * as styles from './time-table-item.css';
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 
@@ -42,14 +43,20 @@ const TimeTableItem = ({
   const [startHour, startMin] = parseTimeString(startTime);
   const [endHour, endMin] = parseTimeString(endTime);
   const [openHour, openMin] = parseTimeString(ticketOpenAt);
-  const totalMin = calcTotalMinutes(startHour, startMin, endHour, endMin);
+  const totalPerformMin = calcTotalMinutes(
+    startHour,
+    startMin,
+    endHour,
+    endMin,
+  );
   const minutesFromOpen = calcMinutesFromOpen(
     startHour,
     startMin,
     openHour,
     openMin,
   );
-  const { top, diff } = calcPosition(totalMin, minutesFromOpen);
+
+  const totalFestivalMinutes = calcTotalFestivalMinutes(openHour, openMin);
 
   const handleSetSelectedBlock = () => {
     if (isEditTimeTableMode) {
@@ -58,11 +65,16 @@ const TimeTableItem = ({
     }
   };
 
+  const top = `calc(${(minutesFromOpen / totalFestivalMinutes) * 100}% + 0.75rem)`;
+  const heightPercentage = `calc((${totalPerformMin} / ${totalFestivalMinutes}) * 100%)`;
+  const left = `calc( 3.1rem + ((100% - 3.5rem) / ${stageCount} * ${stageOrder - 1}))`;
+  const width = `calc((100% - 3.2rem) / ${stageCount})`;
+
   const dynamicVars = assignInlineVars({
-    [styles.stageCount]: stageCount.toString(),
-    [styles.stageOrder]: (stageOrder - 1).toString(),
-    [styles.topPosition]: `${top}rem`,
-    [styles.height]: `${diff}rem`,
+    [styles.left]: left,
+    [styles.width]: width,
+    [styles.top]: top,
+    [styles.height]: heightPercentage,
   });
 
   return (
@@ -76,7 +88,7 @@ const TimeTableItem = ({
       </div>
       <div className={styles.durationP({ isSelected: selectBlock })}>
         {startTime.slice(0, 5)}-{endTime.slice(0, 5)}
-        {`(${totalMin}min)`}
+        {`(${totalPerformMin}min)`}
       </div>
     </div>
   );

--- a/apps/client/src/pages/time-table/components/time-table-item/time-table-item.tsx
+++ b/apps/client/src/pages/time-table/components/time-table-item/time-table-item.tsx
@@ -66,15 +66,15 @@ const TimeTableItem = ({
   };
 
   const top = `calc(${(minutesFromOpen / totalFestivalMinutes) * 100}% + 0.75rem)`;
-  const heightPercentage = `calc((${totalPerformMin} / ${totalFestivalMinutes}) * 100%)`;
-  const left = `calc( 3.1rem + ((100% - 3.5rem) / ${stageCount} * ${stageOrder - 1}))`;
+  const height = `calc((${totalPerformMin} / ${totalFestivalMinutes}) * 100%)`;
+  const left = `calc( 2.9rem + ((100% - 2.9rem) / ${stageCount} * ${stageOrder - 1}))`;
   const width = `calc((100% - 3.2rem) / ${stageCount})`;
 
   const dynamicVars = assignInlineVars({
     [styles.left]: left,
     [styles.width]: width,
     [styles.top]: top,
-    [styles.height]: heightPercentage,
+    [styles.height]: height,
   });
 
   return (

--- a/apps/client/src/pages/time-table/utils/index.ts
+++ b/apps/client/src/pages/time-table/utils/index.ts
@@ -36,3 +36,13 @@ export const calcMinutesFromOpen = (
   const openTotalMin = openHour * ONE_HOUR_TO_MINUTES + openMin;
   return startTotalMin - openTotalMin;
 };
+
+export const calcTotalFestivalMinutes = (
+  startHour: number,
+  startMin: number,
+) => {
+  const hoursUntilEnd = 24 - startHour;
+  const totalFestivalMinutes = hoursUntilEnd * 60 - startMin;
+
+  return totalFestivalMinutes;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@vanilla-extract/css':
         specifier: ^1.17.0
         version: 1.17.0
+      '@vanilla-extract/dynamic':
+        specifier: ^2.1.2
+        version: 2.1.2
       '@vanilla-extract/recipes':
         specifier: ^0.5.5
         version: 0.5.5(@vanilla-extract/css@1.17.0)
@@ -2136,6 +2139,12 @@ packages:
     resolution:
       {
         integrity: sha512-W6FqVFDD+C71ZlKsuj0MxOXSvHb1tvQ9h/+79aYfi097wLsALrnnBzd0by8C///iurrpQ3S+SH74lXd7Lr9MvA==,
+      }
+
+  '@vanilla-extract/dynamic@2.1.2':
+    resolution:
+      {
+        integrity: sha512-9BGMciD8rO1hdSPIAh1ntsG4LPD3IYKhywR7VOmmz9OO4Lx1hlwkSg3E6X07ujFx7YuBfx0GDQnApG9ESHvB2A==,
       }
 
   '@vanilla-extract/integration@7.1.12':
@@ -8991,6 +9000,10 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
 
+  '@vanilla-extract/dynamic@2.1.2':
+    dependencies:
+      '@vanilla-extract/private': 1.0.6
+
   '@vanilla-extract/integration@7.1.12(@types/node@20.16.5)':
     dependencies:
       '@babel/core': 7.26.0
@@ -9051,7 +9064,7 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.2))(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.2)
       '@typescript-eslint/parser': 6.21.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.2)
       eslint-config-prettier: 9.1.0(eslint@9.17.0(jiti@1.21.6))
-      eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.30.0)
+      eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.30.0(@typescript-eslint/parser@6.21.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@9.17.0(jiti@1.21.6)))
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.21.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.2))(eslint-plugin-import@2.30.0)(eslint@9.17.0(jiti@1.21.6))
       eslint-plugin-eslint-comments: 3.2.0(eslint@9.17.0(jiti@1.21.6))
       eslint-plugin-import: 2.30.0(@typescript-eslint/parser@7.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.2))(eslint@9.17.0(jiti@1.21.6))
@@ -10032,7 +10045,7 @@ snapshots:
       eslint: 9.17.0(jiti@1.21.6)
       eslint-plugin-turbo: 2.1.2(eslint@9.17.0(jiti@1.21.6))
 
-  eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.30.0):
+  eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.30.0(@typescript-eslint/parser@6.21.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@9.17.0(jiti@1.21.6))):
     dependencies:
       eslint-plugin-import: 2.30.0(@typescript-eslint/parser@7.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.2))(eslint@9.17.0(jiti@1.21.6))
 
@@ -10050,7 +10063,7 @@ snapshots:
       debug: 4.4.0
       enhanced-resolve: 5.17.1
       eslint: 9.17.0(jiti@1.21.6)
-      eslint-module-utils: 2.11.0(@typescript-eslint/parser@6.21.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@9.17.0(jiti@1.21.6))
+      eslint-module-utils: 2.11.0(@typescript-eslint/parser@6.21.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.21.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.2))(eslint-plugin-import@2.30.0)(eslint@9.17.0(jiti@1.21.6)))(eslint@9.17.0(jiti@1.21.6))
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
@@ -10063,23 +10076,24 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.11.0(@typescript-eslint/parser@6.21.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@9.17.0(jiti@1.21.6)):
+  eslint-module-utils@2.11.0(@typescript-eslint/parser@6.21.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.21.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.2))(eslint-plugin-import@2.30.0)(eslint@9.17.0(jiti@1.21.6)))(eslint@9.17.0(jiti@1.21.6)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 6.21.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.2)
+      eslint: 9.17.0(jiti@1.21.6)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.21.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.2))(eslint-plugin-import@2.30.0)(eslint@9.17.0(jiti@1.21.6))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.11.0(@typescript-eslint/parser@6.21.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.21.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.2))(eslint-plugin-import@2.30.0)(eslint@9.17.0(jiti@1.21.6)))(eslint@9.17.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.21.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.2)
       eslint: 9.17.0(jiti@1.21.6)
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.21.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.2))(eslint-plugin-import@2.30.0)(eslint@9.17.0(jiti@1.21.6))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.11.0(@typescript-eslint/parser@7.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint@9.17.0(jiti@1.21.6)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 7.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.2)
-      eslint: 9.17.0(jiti@1.21.6)
-      eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
@@ -10100,7 +10114,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.17.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.11.0(@typescript-eslint/parser@7.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint@9.17.0(jiti@1.21.6))
+      eslint-module-utils: 2.11.0(@typescript-eslint/parser@6.21.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.21.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.2))(eslint-plugin-import@2.30.0)(eslint@9.17.0(jiti@1.21.6)))(eslint@9.17.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3


### PR DESCRIPTION
## 📌 Summary

> - #311 

타임테이블 픽셀 밀림 현상 개선

## 📚 Tasks

- 타임테이블페이지 테이블 position 계산 로직을 픽셀 단위에서 퍼센트 단위로 수정
- 바닐라익스트렉트 dynamic 의존성 추가
- CSS 변수 관리 방식 개선

## 👀 To Reviewer

### 문제 상황

기존 코드에서는 타임테이블 아이템의 위치를 픽셀 기반(rem 단위)으로 계산하고 있었습니다. 이로 인해 다음과 같은 문제가 발생했습니다:

1. **환경별 렌더링 불일치**: 크롬/사파리에서 픽셀이 다르게 렌더링되어 테이블이 실제 시간에 맞게 정확히 배치되지 않는 현상 발생
2. **해상도 대응 문제**: 기기 해상도에 따라 테이블의 위치가 밀리는 문제 발생
3. **유지보수 어려움**: 픽셀 단위로 하드코딩된 값들로 인해 변경 시 여러 곳을 수정해야 하는 불편함

### 개선 내용
1. **퍼센트 기반 계산 방식으로 로직 수정**:
 테이블의 position을 픽셀 단위가 아닌 퍼센트 단위로 계산하여 환경에 관계없이 일관된 렌더링 제공
  - 기존 방식은 5분에 0.75rem씩 차지하도록 top position을 계산하여 해상도, 환경 차이가 있었음
  - 타임테이블보드의 전체 높이를 100%로 잡고 공연 시작 시간과 페스티벌 오픈 시간의 차이를 퍼센트로 계산하여 정확한 위치에 배치

2. **CSS 변수 관리 개선**:
- 인라인 스타일로 직접 정의하던 방식에서 createVar()와 assignInlineVars를 활용한 방식으로 변경하여 변수 관리를 쉽고 용이하도록 개선했습니다. 

```typeScript
// 기존: React.CSSProperties로 인라인 스타일 정의
style={
  {
    '--stage-count': stageCount,
    '--stage-order': stageOrder - 1,
    '--diff': `${diff}rem`,
    '--top': `${top}rem`,
  } as React.CSSProperties
}

// 개선: vanilla-extract의 dynamic 활용
const dynamicVars = assignInlineVars({
  [styles.left]: left,
  [styles.width]: width,
  [styles.top]: top,
  [styles.height]: heightPercentage,
});
```
#### 바닐라익스트렉트 dynamic 사용 이유
코드리뷰에서 styleVariant()의 사용이 제안되었으나, 다음과 같은 이유로 dynamic 의존성을 설치한 후 assignInlineVars를 사용하는 걸 택했습니다:

- styleVariant()는 미리 정의된 스타일 변형을 선택할 때 유용합니다.
   각 테이블의 position 계산 로직은 정의해둔 변수 값에 따라 동적으로 계산되어있어, 미리 정의해놓을 수 없어 styleVariant로 처리하기 어렵습니다. 또한 스테이지 수, 공연 시간 등은 런타임에 결정되는 값들로, 정적으로 정의된 스타일 변형으로는 처리할 수 없습니다.
- 위치 계산에 필요한 정확한 수식을 직접 CSS 변수에 할당해야 했기 때문에 createVar()와 assignInlineVars를 사용하는 것이 더 적합했습니다.

복잡한 로직이 아니면 기존의 인라인 스타일로 변수를 정의하여 사용하는 로직을 유지해도 되나, 타임테이블의 핵심 로직이고 createVar()로 css 변수를 쉽게 확인하고 수정할 수 있어 추후 로직 관리에 용이할 것 같아 dynamic 의존성을 추가해줬습니다.

### 테스트 결과
- 크롬, 사파리, 모바일 환경과 해상도 변경시에 모두 타임테이블 아이템이 정확한 위치에 렌더링되는 것을 확인했습니다.
- 아이폰 모바일은 확인했으나 서버 측에 cors 허용 도메인 추가를 요청해놓은 상태고, 요청 확인되면 갤럭시폰으로 테스트해서 스크린샷 추가해놓겠습니다! 근데 안될리가 없음 백퍼 될거같음요

## 📸 Screenshot

- 크롬 웹

<img width="930" alt="스크린샷 2025-03-06 오후 8 36 20" src="https://github.com/user-attachments/assets/c0042ff9-50da-4205-a78a-ae5b4663abfb" />

- 사파리 웹

<img width="736" alt="스크린샷 2025-03-06 오후 10 41 45" src="https://github.com/user-attachments/assets/a66179e5-3733-4d65-ab3a-66aac42e2cc3" />


- 아이폰 모바일

![KakaoTalk_Photo_2025-03-06-22-42-10 002](https://github.com/user-attachments/assets/ff1ea87f-1649-483d-a5e7-8670e48df7c2)

- 갤럭시 모바일
갤럭시 확인완료!

![KakaoTalk_Photo_2025-03-09-17-51-35](https://github.com/user-attachments/assets/3b0beed7-66ec-48e6-8358-3a503e97d6e1)

