### PR TITLE
Refactor(client): 날짜 포맷팅 로직 수정

### DIFF
--- a/apps/client/src/pages/home/page/home.tsx
+++ b/apps/client/src/pages/home/page/home.tsx
@@ -8,7 +8,6 @@ import {
 import { USER_DATA } from '@shared/mocks/user-data';
 import { USER_ID_KEY } from '@shared/constants/user-constants';
 import { routePath } from '@shared/constants/path';
-
 import { useUserProfile } from '@pages/my/hooks/use-user-info';
 import { TAB_MENU } from '../constants/menu';
 import { useTicketing } from '../hooks/use-ticketing';
@@ -22,7 +21,6 @@ const Home = () => {
   const { data: profileData } = useUserProfile();
   const isHighlighted = profileData && Number(userId) === USER_DATA.data.userId;
   const navigate = useNavigate();
-
   const handleGoHome = () => navigate(routePath.ROOT);
   const handleGoToTimeTable = () => navigate(routePath.TIME_TABLE_OUTLET);
 

--- a/apps/client/src/pages/performance/components/info/info.tsx
+++ b/apps/client/src/pages/performance/components/info/info.tsx
@@ -24,12 +24,7 @@ const Info = ({
   price,
 }: InfoProps) => {
   const priceLines = price.split('\n');
-  const formattedDate = useFormattedDate(
-    '',
-    'performance-detail',
-    startAt,
-    endAt,
-  );
+  const formattedDate = useFormattedDate('', 'startEndHalf', startAt, endAt);
 
   return (
     <>

--- a/apps/client/src/pages/performance/components/info/info.tsx
+++ b/apps/client/src/pages/performance/components/info/info.tsx
@@ -1,3 +1,4 @@
+import { useFormattedDate } from '@shared/utils/use-format-date';
 import { PERFORMANCE_LABEL } from '../../constant/performance';
 import * as styles from './info.css';
 
@@ -22,8 +23,13 @@ const Info = ({
   reservationOffice,
   price,
 }: InfoProps) => {
-  // 'price'를 분리하여 배열로 변환
   const priceLines = price.split('\n');
+  const formattedDate = useFormattedDate(
+    '',
+    'performance-detail',
+    startAt,
+    endAt,
+  );
 
   return (
     <>
@@ -49,9 +55,7 @@ const Info = ({
               <div className={styles.text({ type: 'label', color: 'gray' })}>
                 {PERFORMANCE_LABEL.PERIOD}
               </div>
-              <div className={styles.text()}>
-                {startAt} - {endAt}
-              </div>
+              <div className={styles.text()}>{formattedDate}</div>
             </div>
             <div className={styles.detail}>
               <div className={styles.text({ type: 'label', color: 'gray' })}>

--- a/apps/client/src/pages/performance/components/summary/summary.tsx
+++ b/apps/client/src/pages/performance/components/summary/summary.tsx
@@ -1,8 +1,8 @@
 import { Button, LikeButton } from '@confeti/design-system';
 import { useLikeMutation } from '@shared/hooks/use-like-mutation';
-import { WEEKDAYS } from '@shared/constants/day.ts';
 import { checkIsNotLoggedIn } from '@shared/utils/check-is-not-logged-in';
 import * as styles from './summary.css';
+import { useFormattedDate } from '@shared/utils/use-format-date';
 
 interface SummaryProps {
   id: number;
@@ -16,21 +16,6 @@ interface SummaryProps {
   isFavorite: boolean;
   type: 'FESTIVAL' | 'CONCERT';
 }
-
-// 날짜 및 시간 포맷팅 함수
-const formatReserveDate = (reserveAt: string): string => {
-  const date = new Date(reserveAt);
-
-  const weekData = WEEKDAYS;
-
-  const hours = date.getHours();
-  const period = hours >= 12 ? '오후' : '오전';
-  const hour12 = hours % 12 === 0 ? 12 : hours % 12;
-
-  const formattedDate = `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일 (${weekData[date.getDay()]}) ${period}${hour12}시`;
-
-  return formattedDate;
-};
 
 const Summary = ({
   id,
@@ -49,6 +34,13 @@ const Summary = ({
   const handleLike = (action: 'LIKE' | 'UNLIKE') => {
     mutate({ id, action, type });
   };
+  const formattedDate = useFormattedDate(
+    '',
+    'performance-detail',
+    startAt,
+    endAt,
+  );
+  const reserverDate = useFormattedDate(reserveAt, 'reserve');
 
   return (
     <section className={styles.container}>
@@ -69,9 +61,7 @@ const Summary = ({
           <div className={styles.detail}>
             <div className={styles.detailItem}>
               <div className={styles.detailTitle}>기간</div>
-              <div className={styles.detailContent}>
-                {startAt} - {endAt}
-              </div>
+              <div className={styles.detailContent}>{formattedDate}</div>
             </div>
             <div className={styles.detailItem}>
               <div className={styles.detailTitle}>장소</div>
@@ -79,9 +69,7 @@ const Summary = ({
             </div>
             <div className={styles.detailItem}>
               <div className={styles.detailTitle}>예매일</div>
-              <div className={styles.detailContent}>
-                {formatReserveDate(reserveAt)}
-              </div>
+              <div className={styles.detailContent}>{reserverDate}</div>
             </div>
           </div>
         </h1>

--- a/apps/client/src/pages/performance/components/summary/summary.tsx
+++ b/apps/client/src/pages/performance/components/summary/summary.tsx
@@ -34,13 +34,8 @@ const Summary = ({
   const handleLike = (action: 'LIKE' | 'UNLIKE') => {
     mutate({ id, action, type });
   };
-  const formattedDate = useFormattedDate(
-    '',
-    'performance-detail',
-    startAt,
-    endAt,
-  );
-  const reserverDate = useFormattedDate(reserveAt, 'reserve');
+  const formattedDate = useFormattedDate('', 'startEndHalf', startAt, endAt);
+  const reserverDate = useFormattedDate(reserveAt, 'koFull');
 
   return (
     <section className={styles.container}>

--- a/apps/client/src/pages/search/components/artist-section.tsx
+++ b/apps/client/src/pages/search/components/artist-section.tsx
@@ -1,3 +1,4 @@
+import { useFormattedDate } from '@shared/utils/use-format-date';
 import ArtistInfo from '../components/artist-info';
 import Title from '../components/title';
 import * as styles from './artist-section.css';
@@ -13,6 +14,9 @@ interface ArtistSectionProps {
 }
 
 const ArtistSection = ({ artist }: ArtistSectionProps) => {
+  const releaseDate = artist[0].latestReleaseAt;
+  const formattedDate = useFormattedDate(releaseDate);
+
   return (
     <div className={styles.section}>
       <Title text="아티스트" />
@@ -22,7 +26,7 @@ const ArtistSection = ({ artist }: ArtistSectionProps) => {
           id={artist.artistId}
           image={artist.profileUrl}
           name={artist.name}
-          releaseDate={artist.latestReleaseAt}
+          releaseDate={formattedDate}
           isFavorite={artist.isFavorite}
         />
       ))}

--- a/apps/client/src/pages/search/components/performance-info.tsx
+++ b/apps/client/src/pages/search/components/performance-info.tsx
@@ -10,7 +10,8 @@ interface PerformanceInfoProps {
   typeId: number;
   posterUrl: string;
   title: string;
-  performanceAt: string;
+  performanceStartAt: string;
+  performanceEndAt: string;
   area: string;
   isFavorite: boolean;
 }
@@ -19,7 +20,8 @@ const PerformanceInfo = ({
   typeId,
   posterUrl,
   title,
-  performanceAt,
+  performanceStartAt,
+  performanceEndAt,
   area,
   isFavorite,
   type,
@@ -56,7 +58,7 @@ const PerformanceInfo = ({
 
           <div className={styles.infoRow}>
             <IcTimeGray14 className={styles.infoIcon} />
-            <p className={styles.infoText}>{performanceAt}</p>
+            <p className={styles.infoText}>{'dd'}</p>
           </div>
 
           <div className={styles.infoRow}>

--- a/apps/client/src/pages/search/components/performance-info.tsx
+++ b/apps/client/src/pages/search/components/performance-info.tsx
@@ -4,6 +4,7 @@ import { LikeButton } from '@confeti/design-system';
 import { useLikeMutation } from '@shared/hooks/use-like-mutation';
 import { checkIsNotLoggedIn } from '@shared/utils/check-is-not-logged-in';
 import * as styles from './performance-info.css';
+import { useFormattedDate } from '@shared/utils/use-format-date';
 
 interface PerformanceInfoProps {
   type: 'FESTIVAL' | 'CONCERT' | 'ARTIST';
@@ -41,6 +42,13 @@ const PerformanceInfo = ({
     navigate(path);
   };
 
+  const formattedDate = useFormattedDate(
+    '',
+    'performance',
+    performanceStartAt,
+    performanceEndAt,
+  );
+
   return (
     <div className={styles.container}>
       <div className={styles.wrapper}>
@@ -58,7 +66,7 @@ const PerformanceInfo = ({
 
           <div className={styles.infoRow}>
             <IcTimeGray14 className={styles.infoIcon} />
-            <p className={styles.infoText}>{'dd'}</p>
+            <p className={styles.infoText}>{formattedDate}</p>
           </div>
 
           <div className={styles.infoRow}>

--- a/apps/client/src/pages/search/components/performance-info.tsx
+++ b/apps/client/src/pages/search/components/performance-info.tsx
@@ -44,7 +44,7 @@ const PerformanceInfo = ({
 
   const formattedDate = useFormattedDate(
     '',
-    'performance',
+    'startEndFull',
     performanceStartAt,
     performanceEndAt,
   );

--- a/apps/client/src/pages/search/components/performance-section.tsx
+++ b/apps/client/src/pages/search/components/performance-section.tsx
@@ -35,7 +35,8 @@ const PerformanceSection = ({ performances }: PerformanceSectionProps) => {
             typeId={performance.typeId}
             type={performance.type}
             title={performance.title}
-            performanceAt={`${performance.performanceStartAt} - ${performance.performanceEndAt}`}
+            performanceStartAt={performance.performanceStartAt}
+            performanceEndAt={performance.performanceEndAt}
             posterUrl={performance.posterUrl}
             area={performance.area}
             isFavorite={performance.isFavorite}

--- a/apps/client/src/pages/time-table/components/booth-open-box/booth-open-box.tsx
+++ b/apps/client/src/pages/time-table/components/booth-open-box/booth-open-box.tsx
@@ -9,7 +9,7 @@ const BoothOpenBox = ({ ticketOpenHour }: BoxProps) => {
   return (
     <div className={styles.wrapper}>
       {'TICKET BOOTH OPEN '}
-      {openHour}:{openMin.toString().padStart(2, '0')}
+      {openHour}:{openMin}
     </div>
   );
 };

--- a/apps/client/src/pages/time-table/components/calender/calender.tsx
+++ b/apps/client/src/pages/time-table/components/calender/calender.tsx
@@ -1,12 +1,12 @@
 import { cn } from '@confeti/design-system/utils';
 import {
-  useFormattedYear,
   useFormattedWeek,
   useDayNumSelection,
   createFestivalDateMap,
   checkFestivalDateStatus,
 } from '@pages/time-table/hooks/use-data-formatted';
 import * as styles from './calender.css';
+import { useFormattedDate } from '@shared/utils/use-format-date';
 
 interface CalenderProps {
   festivalDates: { festivalDateId: number; festivalAt: string }[];
@@ -20,7 +20,7 @@ const Calender = ({ festivalDates, onDateSelect }: CalenderProps) => {
   const { selectedDayNumId, handleDayNumClick } = useDayNumSelection(
     festivalDates || [],
   );
-  const formattedYear = useFormattedYear(firstDate);
+  const formattedYear = useFormattedDate(firstDate, 'timetable');
 
   const handleDateClick = (festivalDateId: number) => {
     handleDayNumClick(festivalDateId);

--- a/apps/client/src/pages/time-table/components/calender/calender.tsx
+++ b/apps/client/src/pages/time-table/components/calender/calender.tsx
@@ -20,7 +20,7 @@ const Calender = ({ festivalDates, onDateSelect }: CalenderProps) => {
   const { selectedDayNumId, handleDayNumClick } = useDayNumSelection(
     festivalDates || [],
   );
-  const formattedYear = useFormattedDate(firstDate, 'timetable');
+  const formattedYear = useFormattedDate(firstDate, 'koHalf');
 
   const handleDateClick = (festivalDateId: number) => {
     handleDayNumClick(festivalDateId);

--- a/apps/client/src/pages/time-table/components/time-table-board/time-table-board.tsx
+++ b/apps/client/src/pages/time-table/components/time-table-board/time-table-board.tsx
@@ -34,7 +34,7 @@ const TimeTableBoard = ({
   const [openHour, openMin] = parseTimeString(timeTableInfo.ticketOpenAt);
   const isHalfHourOpen = Number(openMin) === HALF_HOUR_TO_MINUTES;
   const ticketOpenHour = isHalfHourOpen ? openHour + 1 : openHour;
-  const cellNumber = generateTableRow(Number(ticketOpenHour));
+  const cellNumber = generateTableRow(ticketOpenHour);
 
   const [selectedItems, setSelectedItems] = useState<
     { userTimetableId: number; isSelected: boolean }[]

--- a/apps/client/src/pages/time-table/components/time-table-board/time-table-board.tsx
+++ b/apps/client/src/pages/time-table/components/time-table-board/time-table-board.tsx
@@ -32,9 +32,9 @@ const TimeTableBoard = ({
     fileName: `${clickedFestivalTitle}`,
   });
   const [openHour, openMin] = parseTimeString(timeTableInfo.ticketOpenAt);
-  const isHalfHourOpen = openMin === HALF_HOUR_TO_MINUTES;
+  const isHalfHourOpen = Number(openMin) === HALF_HOUR_TO_MINUTES;
   const ticketOpenHour = isHalfHourOpen ? openHour + 1 : openHour;
-  const cellNumber = generateTableRow(ticketOpenHour);
+  const cellNumber = generateTableRow(Number(ticketOpenHour));
 
   const [selectedItems, setSelectedItems] = useState<
     { userTimetableId: number; isSelected: boolean }[]

--- a/apps/client/src/pages/time-table/components/time-table-item/time-table-item.tsx
+++ b/apps/client/src/pages/time-table/components/time-table-item/time-table-item.tsx
@@ -11,8 +11,8 @@ import { assignInlineVars } from '@vanilla-extract/dynamic';
 
 interface ItemProps {
   artists: Artist[];
-  startTime: string | number;
-  endTime: string | number;
+  startTime: string;
+  endTime: string;
   stageCount: number;
   isSelected: boolean;
   stageOrder: number;

--- a/apps/client/src/pages/time-table/components/time-table-item/time-table-item.tsx
+++ b/apps/client/src/pages/time-table/components/time-table-item/time-table-item.tsx
@@ -11,8 +11,8 @@ import { assignInlineVars } from '@vanilla-extract/dynamic';
 
 interface ItemProps {
   artists: Artist[];
-  startTime: string;
-  endTime: string;
+  startTime: string | number;
+  endTime: string | number;
   stageCount: number;
   isSelected: boolean;
   stageOrder: number;
@@ -87,7 +87,7 @@ const TimeTableItem = ({
         {artists.map((artist) => artist.artistName).join(', ')}
       </div>
       <div className={styles.durationP({ isSelected: selectBlock })}>
-        {startTime.slice(0, 5)}-{endTime.slice(0, 5)}
+        {`${startHour}:${startMin}-${endHour}:${endMin}`}
         {`(${totalPerformMin}min)`}
       </div>
     </div>

--- a/apps/client/src/pages/time-table/hooks/use-data-formatted.ts
+++ b/apps/client/src/pages/time-table/hooks/use-data-formatted.ts
@@ -1,24 +1,7 @@
 import { useState, useMemo, useEffect } from 'react';
 import { WEEKDAYS } from '@shared/constants/day';
 
-const YEAR_MESSAGE = {
-  ERR_MESSAGE: '',
-};
-
 const weekData = WEEKDAYS;
-
-export const useFormattedYear = (date: string | null) => {
-  if (!date) {
-    return ``;
-  }
-
-  const [year, month] = date.split('.') || [];
-  if (!year || !month) {
-    return `${YEAR_MESSAGE.ERR_MESSAGE}`;
-  }
-
-  return `${year}년 ${parseInt(month, 10)}월`;
-};
 
 /**
  * 특정 날짜 기준으로 일주일 동안의 날짜(num) 값을 계산하고 반환함
@@ -27,8 +10,10 @@ export const useFormattedWeek = (date: string | null) => {
   return useMemo(() => {
     if (!date) return { weekDays: [] };
 
-    const [year, month, day] = date
-      .split('.')
+    const datePart = date.split('T')[0];
+
+    const [year, month, day] = datePart
+      .split('-')
       .map((part) => parseInt(part, 10));
     if (isNaN(year) || isNaN(month) || isNaN(day)) return { weekDays: [] };
 

--- a/apps/client/src/pages/time-table/types/type-guards.ts
+++ b/apps/client/src/pages/time-table/types/type-guards.ts
@@ -1,0 +1,7 @@
+export const isString = (value: number | string): value is string => {
+  return typeof value === 'string';
+};
+
+export const isNumber = (value: number | string): value is number => {
+  return typeof value === 'number';
+};

--- a/apps/client/src/pages/time-table/types/type-guards.ts
+++ b/apps/client/src/pages/time-table/types/type-guards.ts
@@ -1,7 +1,0 @@
-export const isString = (value: number | string): value is string => {
-  return typeof value === 'string';
-};
-
-export const isNumber = (value: number | string): value is number => {
-  return typeof value === 'number';
-};

--- a/apps/client/src/pages/time-table/utils/index.ts
+++ b/apps/client/src/pages/time-table/utils/index.ts
@@ -26,15 +26,15 @@ export const calcPosition = (totalMin: number, minutesFromOpen: number) => {
 };
 
 export const calcTotalMinutes = (
-  startHour: number | string,
-  startMin: number | string,
-  endHour: number | string,
-  endMin: number | string,
+  startHour: string,
+  startMin: string,
+  endHour: string,
+  endMin: string,
 ) => {
-  const startHourNum = isString(startHour) ? Number(startHour) : startHour;
-  const startMinNum = isString(startMin) ? Number(startMin) : startMin;
-  const endHourNum = isString(endHour) ? Number(endHour) : endHour;
-  const endMinNum = isString(endMin) ? Number(endMin) : endMin;
+  const startHourNum = Number(startHour);
+  const startMinNum = Number(startMin);
+  const endHourNum = Number(endHour);
+  const endMinNum = Number(endMin);
 
   return (
     endHourNum * 60 +
@@ -44,15 +44,15 @@ export const calcTotalMinutes = (
 };
 
 export const calcMinutesFromOpen = (
-  startHour: number | string,
-  startMin: number | string,
-  openHour: number | string,
-  openMin: number | string,
+  startHour: string,
+  startMin: string,
+  openHour: string,
+  openMin: string,
 ) => {
-  const startHourNum = isString(startHour) ? Number(startHour) : startHour;
-  const startMinNum = isString(startMin) ? Number(startMin) : startMin;
-  const openHourNum = isString(openHour) ? Number(openHour) : openHour;
-  const openMinNum = isString(openMin) ? Number(openMin) : openMin;
+  const startHourNum = Number(startHour);
+  const startMinNum = Number(startMin);
+  const openHourNum = Number(openHour);
+  const openMinNum = Number(openMin);
 
   const startTotalMin = startHourNum * ONE_HOUR_TO_MINUTES + startMinNum;
   const openTotalMin = openHourNum * ONE_HOUR_TO_MINUTES + openMinNum;
@@ -61,11 +61,11 @@ export const calcMinutesFromOpen = (
 };
 
 export const calcTotalFestivalMinutes = (
-  startHour: number | string,
-  startMin: number | string,
+  startHour: string,
+  startMin: string,
 ) => {
-  const startHourNum = isString(startHour) ? Number(startHour) : startHour;
-  const startMinNum = isString(startMin) ? Number(startMin) : startMin;
+  const startHourNum = Number(startHour);
+  const startMinNum = Number(startMin);
 
   const hoursUntilEnd = 24 - startHourNum;
   const totalFestivalMinutes = hoursUntilEnd * 60 - startMinNum;

--- a/apps/client/src/pages/time-table/utils/index.ts
+++ b/apps/client/src/pages/time-table/utils/index.ts
@@ -3,8 +3,9 @@ import {
   ONE_HOUR_TO_MINUTES,
 } from '@pages/time-table/constants';
 
-export const generateTableRow = (startTime: number) => {
-  return Array.from({ length: 24 - startTime }, (_, idx) => startTime + idx);
+export const generateTableRow = (startTime: string) => {
+  const startHour = Number(startTime);
+  return Array.from({ length: 24 - startHour }, (_, idx) => startHour + idx);
 };
 
 export const parseTimeString = (timeString: string): string[] => {

--- a/apps/client/src/pages/time-table/utils/index.ts
+++ b/apps/client/src/pages/time-table/utils/index.ts
@@ -2,13 +2,21 @@ import {
   TIME_SLOT_HEIGHT_5_MIN,
   ONE_HOUR_TO_MINUTES,
 } from '@pages/time-table/constants';
+import { isString } from '../types/type-guards';
 
 export const generateTableRow = (startTime: number) => {
   return Array.from({ length: 24 - startTime }, (_, idx) => startTime + idx);
 };
 
-export const parseTimeString = (timeString: string): number[] => {
-  return timeString.slice(0, 5).split(':').map(Number);
+export const parseTimeString = (timeString: string | number): string[] => {
+  const time = isString(timeString)
+    ? timeString.split('T')[1]?.slice(0, 5)
+    : '';
+
+  if (!time) return ['00', '00'];
+
+  const [hour, min] = time.split(':');
+  return [hour, min.padStart(2, '0')];
 };
 
 export const calcPosition = (totalMin: number, minutesFromOpen: number) => {
@@ -18,31 +26,49 @@ export const calcPosition = (totalMin: number, minutesFromOpen: number) => {
 };
 
 export const calcTotalMinutes = (
-  startHour: number,
-  startMin: number,
-  endHour: number,
-  endMin: number,
+  startHour: number | string,
+  startMin: number | string,
+  endHour: number | string,
+  endMin: number | string,
 ) => {
-  return endHour * 60 + endMin - (startHour * ONE_HOUR_TO_MINUTES + startMin);
+  const startHourNum = isString(startHour) ? Number(startHour) : startHour;
+  const startMinNum = isString(startMin) ? Number(startMin) : startMin;
+  const endHourNum = isString(endHour) ? Number(endHour) : endHour;
+  const endMinNum = isString(endMin) ? Number(endMin) : endMin;
+
+  return (
+    endHourNum * 60 +
+    endMinNum -
+    (startHourNum * ONE_HOUR_TO_MINUTES + startMinNum)
+  );
 };
 
 export const calcMinutesFromOpen = (
-  startHour: number,
-  startMin: number,
-  openHour: number,
-  openMin: number,
+  startHour: number | string,
+  startMin: number | string,
+  openHour: number | string,
+  openMin: number | string,
 ) => {
-  const startTotalMin = startHour * ONE_HOUR_TO_MINUTES + startMin;
-  const openTotalMin = openHour * ONE_HOUR_TO_MINUTES + openMin;
+  const startHourNum = isString(startHour) ? Number(startHour) : startHour;
+  const startMinNum = isString(startMin) ? Number(startMin) : startMin;
+  const openHourNum = isString(openHour) ? Number(openHour) : openHour;
+  const openMinNum = isString(openMin) ? Number(openMin) : openMin;
+
+  const startTotalMin = startHourNum * ONE_HOUR_TO_MINUTES + startMinNum;
+  const openTotalMin = openHourNum * ONE_HOUR_TO_MINUTES + openMinNum;
+
   return startTotalMin - openTotalMin;
 };
 
 export const calcTotalFestivalMinutes = (
-  startHour: number,
-  startMin: number,
+  startHour: number | string,
+  startMin: number | string,
 ) => {
-  const hoursUntilEnd = 24 - startHour;
-  const totalFestivalMinutes = hoursUntilEnd * 60 - startMin;
+  const startHourNum = isString(startHour) ? Number(startHour) : startHour;
+  const startMinNum = isString(startMin) ? Number(startMin) : startMin;
+
+  const hoursUntilEnd = 24 - startHourNum;
+  const totalFestivalMinutes = hoursUntilEnd * 60 - startMinNum;
 
   return totalFestivalMinutes;
 };

--- a/apps/client/src/pages/time-table/utils/index.ts
+++ b/apps/client/src/pages/time-table/utils/index.ts
@@ -2,16 +2,13 @@ import {
   TIME_SLOT_HEIGHT_5_MIN,
   ONE_HOUR_TO_MINUTES,
 } from '@pages/time-table/constants';
-import { isString } from '../types/type-guards';
 
 export const generateTableRow = (startTime: number) => {
   return Array.from({ length: 24 - startTime }, (_, idx) => startTime + idx);
 };
 
-export const parseTimeString = (timeString: string | number): string[] => {
-  const time = isString(timeString)
-    ? timeString.split('T')[1]?.slice(0, 5)
-    : '';
+export const parseTimeString = (timeString: string): string[] => {
+  const time = timeString.split('T')[1]?.slice(0, 5);
 
   if (!time) return ['00', '00'];
 

--- a/apps/client/src/pages/time-table/utils/index.ts
+++ b/apps/client/src/pages/time-table/utils/index.ts
@@ -16,7 +16,7 @@ export const parseTimeString = (timeString: string | number): string[] => {
   if (!time) return ['00', '00'];
 
   const [hour, min] = time.split(':');
-  return [hour, min.padStart(2, '0')];
+  return [hour, min];
 };
 
 export const calcPosition = (totalMin: number, minutesFromOpen: number) => {

--- a/apps/client/src/shared/utils/use-format-date.ts
+++ b/apps/client/src/shared/utils/use-format-date.ts
@@ -3,8 +3,8 @@ import { WEEKDAYS } from '@shared/constants/day';
 const getDateParts = (date: string) => {
   const parsedDate = new Date(date);
   const year = parsedDate.getFullYear();
-  const month = parsedDate.getMonth() + 1;
-  const day = parsedDate.getDate();
+  const month = String(parsedDate.getMonth() + 1).padStart(2, '0');
+  const day = String(parsedDate.getDate()).padStart(2, '0');
 
   return { year, month, day };
 };
@@ -40,15 +40,15 @@ const getReserveDate = (reserveAt: string): string => {
 
 export const useFormattedDate = (
   date: string = '',
-  domain: string = 'default',
+  formatStyle: string = 'default',
   startAt?: string,
   endAt?: string,
 ) => {
-  if (domain === 'performance' && startAt && endAt) {
+  if (formatStyle === 'startEndFull' && startAt && endAt) {
     return getStartAtEndAt(startAt, endAt, false);
   }
 
-  if (domain === 'performance-detail' && startAt && endAt) {
+  if (formatStyle === 'startEndHalf' && startAt && endAt) {
     return getStartAtEndAt(startAt, endAt, true);
   }
 
@@ -56,10 +56,10 @@ export const useFormattedDate = (
 
   const { year, month, day } = getDateParts(date);
 
-  switch (domain) {
-    case 'timetable':
+  switch (formatStyle) {
+    case 'koHalf':
       return `${year}년 ${month}월`;
-    case 'reserve':
+    case 'koFull':
       return getReserveDate(date);
     default:
       return `${year}.${month}.${day}`;

--- a/apps/client/src/shared/utils/use-format-date.ts
+++ b/apps/client/src/shared/utils/use-format-date.ts
@@ -1,0 +1,67 @@
+import { WEEKDAYS } from '@shared/constants/day';
+
+const getDateParts = (date: string) => {
+  const parsedDate = new Date(date);
+  const year = parsedDate.getFullYear();
+  const month = parsedDate.getMonth() + 1;
+  const day = parsedDate.getDate();
+
+  return { year, month, day };
+};
+
+const getStartAtEndAt = (
+  startAt: string,
+  endAt: string,
+  isPerformanceDetail: boolean,
+) => {
+  const {
+    year: startYear,
+    month: startMonth,
+    day: startDay,
+  } = getDateParts(startAt);
+  const { year: endYear, month: endMonth, day: endDay } = getDateParts(endAt);
+
+  return `${startYear}.${startMonth}.${startDay} - ${isPerformanceDetail ? `${endYear}.${endMonth}.${endDay}` : `${endMonth}.${endDay}`}`;
+};
+
+const getReserveDate = (reserveAt: string): string => {
+  const parsedDate = new Date(reserveAt);
+
+  const weekData = WEEKDAYS;
+
+  const hours = parsedDate.getHours();
+  const period = hours >= 12 ? '오후' : '오전';
+  const hour12 = hours % 12 === 0 ? 12 : hours % 12;
+
+  const formattedDate = `${parsedDate.getFullYear()}년 ${parsedDate.getMonth() + 1}월 ${parsedDate.getDate()}일 (${weekData[parsedDate.getDay()]}) ${period}${hour12}시`;
+
+  return formattedDate;
+};
+
+export const useFormattedDate = (
+  date: string = '',
+  domain: string = 'default',
+  startAt?: string,
+  endAt?: string,
+) => {
+  if (domain === 'performance' && startAt && endAt) {
+    return getStartAtEndAt(startAt, endAt, false);
+  }
+
+  if (domain === 'performance-detail' && startAt && endAt) {
+    return getStartAtEndAt(startAt, endAt, true);
+  }
+
+  if (!date) return '';
+
+  const { year, month, day } = getDateParts(date);
+
+  switch (domain) {
+    case 'timetable':
+      return `${year}년 ${month}월`;
+    case 'reserve':
+      return getReserveDate(date);
+    default:
+      return `${year}.${month}.${day}`;
+  }
+};

--- a/apps/client/src/shared/utils/use-format-date.ts
+++ b/apps/client/src/shared/utils/use-format-date.ts
@@ -1,5 +1,11 @@
 import { WEEKDAYS } from '@shared/constants/day';
 
+/**
+ * 주어진 날짜 문자열에서 연, 월, 일을 추출하여 반환합니다.
+ * @param {string} date - 날짜 문자열 (예: "2025-04-09")
+ * @returns {{year: string, month: string, day: string}} - 연, 월(2자리), 일(2자리)
+ */
+
 const getDateParts = (date: string) => {
   const parsedDate = new Date(date);
   const year = parsedDate.getFullYear();
@@ -8,6 +14,14 @@ const getDateParts = (date: string) => {
 
   return { year, month, day };
 };
+
+/**
+ * 시작 날짜와 종료 날짜를 받아 형식에 맞는 날짜 문자열을 반환합니다.
+ * @param {string} startAt - 시작 날짜 (예: "2025-04-09")
+ * @param {string} endAt - 종료 날짜 (예: "2025-10-03")
+ * @param {boolean} isPerformanceDetail - true이면 연도를 포함한 날짜 형식 사용
+ * @returns {string} - 포맷된 날짜 문자열 (예: "2025.04.09 - 10.03" 또는 "2025.04.09 - 2025.10.03")
+ */
 
 const getStartAtEndAt = (
   startAt: string,
@@ -23,6 +37,12 @@ const getStartAtEndAt = (
 
   return `${startYear}.${startMonth}.${startDay} - ${isPerformanceDetail ? `${endYear}.${endMonth}.${endDay}` : `${endMonth}.${endDay}`}`;
 };
+
+/**
+ * 예약 날짜를 포맷된 문자열로 변환합니다.
+ * @param {string} reserveAt - 예약 날짜 문자열 (예: "2025-03-10T15:00:00Z")
+ * @returns {string} - 포맷된 날짜 문자열 (예: "2025년 3월 10일 (월) 오후 3시")
+ */
 
 const getReserveDate = (reserveAt: string): string => {
   const parsedDate = new Date(reserveAt);


### PR DESCRIPTION
## 📌 Summary

* #323 

## 📚 Tasks

* 날짜 포맷팅 중앙관리를 위한 유틸 함수 추가
* 타입 가드 함수 추가

## 👀 To Reviewer

날짜 데이터 형식이 서버에서 통일되어 내려오게 되었어요 기존에는 통일되지 않았기에 프론트에서 데이터를 재가공하는데 있어서 거의 동일한 역할을 하는 함수가 도메인별로 존재하는 것이 불필요하다 생각하여 해당 로직을 유틸함수로 관리하기 위해서 데이터 형식을 통일시켜달라고 요청하였어요

역시나 서버에서 데이터 형식을 변경하자마자 타임 테이블, 상세 페이지 검색 페이지, 등등 거의 대부분의 페이지에서 화면이 렌더링 되지 않거나 하는 에러가 발생했고, 서버에 대한 의존도가 매우 높다는 것을 알 수 있었어요

유틸함수로 관리하더라도 서버에서 데이터 형식을 변경한다면 똑같이 에러가 발생하겠지만 중앙에서 관리하기 때문에 중앙에서 로직만 수정해주면 이번 작업과 같이 유지 보수에 많은 리소스가 들지 않을 수 있을 것 같아요.

❗home 상단 캐러셀에는 아직 날짜 포맷팅을 적용시키지 않고 있는데, gui 가 크게 변경되기 때문에 일부로 수정하지 않았습니다. 다음번에 해당 캐러셀 작업하시는 분이 유틸 함수 이용해서 처리해주시면 좋을 것 같아요

💣리뷰로 변경 사항 달아두겠습니다

