### PR TITLE
Refactor(design-system): SearchBar 컴포넌트 수정

### DIFF
--- a/apps/client/src/pages/search/hooks/use-search-logic.ts
+++ b/apps/client/src/pages/search/hooks/use-search-logic.ts
@@ -27,7 +27,6 @@ export const useSearchLogic = () => {
       setTimeout(() => {
         navigate(`${routePath.SEARCH}?q=${searchKeyword}`);
         setBarFocus(false);
-        setSearchKeyword('');
         (e.target as HTMLInputElement).blur();
       }, 0);
     }

--- a/apps/client/src/pages/search/page/search.tsx
+++ b/apps/client/src/pages/search/page/search.tsx
@@ -13,6 +13,7 @@ const Search = () => {
   const {
     artistData,
     paramsKeyword,
+    searchKeyword,
     barFocus,
     handleOnChange,
     handleKeydown,
@@ -33,6 +34,7 @@ const Search = () => {
   return (
     <>
       <SearchBar
+        value={searchKeyword}
         onChange={handleOnChange}
         onKeyDown={handleKeydown}
         onFocus={handleOnFocus}

--- a/packages/design-system/src/components/search-bar/search-bar.css.ts
+++ b/packages/design-system/src/components/search-bar/search-bar.css.ts
@@ -14,6 +14,11 @@ export const frame = style({
   display: 'flex',
   alignItems: 'center',
   width: '100%',
+  gap: '0.5rem',
+});
+
+export const arrowButton = style({
+  cursor: 'pointer',
 });
 
 export const searchBar = recipe({
@@ -22,9 +27,9 @@ export const searchBar = recipe({
     alignItems: 'center',
     width: '100%',
     height: '3.8rem',
-    padding: '1rem 1.2rem',
+    padding: '1rem 1.4rem',
+    backgroundColor: themeVars.color.gray200,
     borderRadius: '2.1rem',
-    border: themeVars.border.black,
   },
   variants: {
     type: {
@@ -41,11 +46,12 @@ export const textSection = style({
   width: '100%',
   marginLeft: '0.6rem',
   backgroundColor: 'transparent',
-  caretColor: themeVars.color.confeti_lime,
+  caretColor: themeVars.color.black,
 
   selectors: {
     '&::placeholder': {
-      color: themeVars.color.gray400,
+      ...themeVars.fontStyles.body2_r_15,
+      color: themeVars.color.gray500,
     },
     '&:focus': {
       outline: 'none',
@@ -54,9 +60,5 @@ export const textSection = style({
 });
 
 export const closeBtn = style({
-  cursor: 'pointer',
-});
-
-export const arrowButton = style({
   cursor: 'pointer',
 });

--- a/packages/design-system/src/components/search-bar/search-bar.tsx
+++ b/packages/design-system/src/components/search-bar/search-bar.tsx
@@ -11,6 +11,7 @@ interface SearchBarProps {
   onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   onFocus?: () => void;
   onBlur?: () => void;
+  placeholder?: string;
 }
 
 export const SearchBar = ({
@@ -19,6 +20,7 @@ export const SearchBar = ({
   onKeyDown,
   onFocus,
   onBlur,
+  placeholder = '아티스트 또는 공연을 검색해보세요!',
 }: SearchBarProps) => {
   const textInput = useRef<HTMLInputElement>(null);
   const [showClearBtn, setShowClearBtn] = useState(false);
@@ -66,7 +68,7 @@ export const SearchBar = ({
           <input
             className={styles.textSection}
             type="text"
-            placeholder="아티스트 또는 공연을 검색해보세요!"
+            placeholder={placeholder}
             ref={textInput}
             value={value}
             onChange={handleInputChange}

--- a/packages/design-system/src/components/search-bar/search-bar.tsx
+++ b/packages/design-system/src/components/search-bar/search-bar.tsx
@@ -20,12 +20,12 @@ export const SearchBar = ({
   onChange,
   onKeyDown,
   onFocus,
-  onBlur,
   showBackButton = true,
   placeholder = '아티스트 또는 공연을 검색해보세요!',
 }: SearchBarProps) => {
   const textInput = useRef<HTMLInputElement>(null);
   const [showClearBtn, setShowClearBtn] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
   const navigate = useNavigate();
 
   const handleClear = () => {
@@ -33,6 +33,7 @@ export const SearchBar = ({
       textInput.current.value = '';
       textInput.current.focus();
       setShowClearBtn(false);
+      setIsFocused(false);
       if (onChange) {
         onChange({
           target: { value: '' },
@@ -72,14 +73,22 @@ export const SearchBar = ({
           <input
             className={styles.textSection}
             type="text"
-            placeholder={placeholder}
+            placeholder={isFocused ? '' : placeholder}
             ref={textInput}
             value={value}
             onChange={handleInputChange}
             onKeyDown={onKeyDown}
-            onFocus={onFocus}
-            onBlur={onBlur}
-            enterKeyHint="search"
+            onFocus={() => {
+              setIsFocused(true);
+              setShowClearBtn(true);
+              onFocus?.();
+            }}
+            onBlur={() => {
+              if (!value) {
+                setIsFocused(false);
+                setShowClearBtn(false);
+              }
+            }}
           />
           {showClearBtn && (
             <SvgBtnClose

--- a/packages/design-system/src/components/search-bar/search-bar.tsx
+++ b/packages/design-system/src/components/search-bar/search-bar.tsx
@@ -19,7 +19,6 @@ export const SearchBar = ({
   value,
   onChange,
   onKeyDown,
-  onFocus,
   showBackButton = true,
   placeholder = '아티스트 또는 공연을 검색해보세요!',
 }: SearchBarProps) => {
@@ -81,7 +80,6 @@ export const SearchBar = ({
             onFocus={() => {
               setIsFocused(true);
               setShowClearBtn(true);
-              onFocus?.();
             }}
             onBlur={() => {
               if (!value) {

--- a/packages/design-system/src/components/search-bar/search-bar.tsx
+++ b/packages/design-system/src/components/search-bar/search-bar.tsx
@@ -11,6 +11,7 @@ interface SearchBarProps {
   onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   onFocus?: () => void;
   onBlur?: () => void;
+  showBackButton?: boolean;
   placeholder?: string;
 }
 
@@ -20,6 +21,7 @@ export const SearchBar = ({
   onKeyDown,
   onFocus,
   onBlur,
+  showBackButton = true,
   placeholder = '아티스트 또는 공연을 검색해보세요!',
 }: SearchBarProps) => {
   const textInput = useRef<HTMLInputElement>(null);
@@ -53,12 +55,14 @@ export const SearchBar = ({
   return (
     <div className={styles.container}>
       <div className={styles.frame}>
-        <SvgBtnArrowLeft20
-          width={20}
-          height={20}
-          onClick={handleBackClick}
-          className={styles.arrowButton}
-        />
+        {showBackButton && (
+          <SvgBtnArrowLeft20
+            width={20}
+            height={20}
+            onClick={handleBackClick}
+            className={styles.arrowButton}
+          />
+        )}
         <div className={styles.searchBar({ type: 'default' })}>
           <SvgIcNewSearchGray18
             className={styles.searchIcon}

--- a/packages/design-system/src/components/search-bar/search-bar.tsx
+++ b/packages/design-system/src/components/search-bar/search-bar.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import SvgIcSicGray18 from '../../icons/src/IcSicGray18';
+import SvgIcNewSearchGray18 from '../../icons/src/IcNewSearchGray18';
 import SvgBtnArrowLeft20 from '../../icons/src/BtnArrowLeft20';
 import SvgBtnClose from '../../icons/src/BtnClose';
 import * as styles from './search-bar.css';
@@ -58,7 +58,7 @@ export const SearchBar = ({
           className={styles.arrowButton}
         />
         <div className={styles.searchBar({ type: 'default' })}>
-          <SvgIcSicGray18
+          <SvgIcNewSearchGray18
             className={styles.searchIcon}
             width={18}
             height={18}
@@ -66,7 +66,7 @@ export const SearchBar = ({
           <input
             className={styles.textSection}
             type="text"
-            placeholder="아티스트를 검색해주세요"
+            placeholder="아티스트 또는 공연을 검색해보세요!"
             ref={textInput}
             value={value}
             onChange={handleInputChange}

--- a/packages/design-system/src/icons/assets/ic_new_search_gray_18.svg
+++ b/packages/design-system/src/icons/assets/ic_new_search_gray_18.svg
@@ -1,0 +1,6 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="ic_new_search_gray_18">
+<circle id="Ellipse 84" cx="8.357" cy="7.71443" r="4.82143" stroke="#93959D" stroke-width="1.92857"/>
+<path id="Vector 116" d="M11.5713 12.2871L13.6198 15.4263" stroke="#93959D" stroke-width="1.92857" stroke-linecap="round"/>
+</g>
+</svg>

--- a/packages/design-system/src/icons/src/IcNewSearchGray18.tsx
+++ b/packages/design-system/src/icons/src/IcNewSearchGray18.tsx
@@ -1,0 +1,17 @@
+import type { SVGProps } from 'react';
+const SvgIcNewSearchGray18 = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1em"
+    height="1em"
+    fill="none"
+    viewBox="0 0 18 18"
+    {...props}
+  >
+    <g stroke="#93959D" strokeWidth={1.929}>
+      <circle cx={8.357} cy={7.714} r={4.821} />
+      <path strokeLinecap="round" d="m11.571 12.287 2.049 3.14" />
+    </g>
+  </svg>
+);
+export default SvgIcNewSearchGray18;

--- a/packages/design-system/src/icons/src/index.ts
+++ b/packages/design-system/src/icons/src/index.ts
@@ -28,6 +28,7 @@ export { default as IcFloatEditLime24 } from './IcFloatEditLime24';
 export { default as IcIndicatorActive } from './IcIndicatorActive';
 export { default as IcIndicatorDefault } from './IcIndicatorDefault';
 export { default as IcKakao } from './IcKakao';
+export { default as IcNewSearchGray18 } from './IcNewSearchGray18';
 export { default as IcPlaceGray14 } from './IcPlaceGray14';
 export { default as IcSelect } from './IcSelect';
 export { default as IcSicGray18 } from './IcSicGray18';


### PR DESCRIPTION
## 📌 Summary

> - #333 

SearchBar 컴포넌트를 수정했어요

## 📚 Tasks

- 아이콘 수정
- 뒤로가기 아이콘 조건부 렌더링
- 각종 자잘한 수정...

## 👀 To Reviewer

1. placeholder를 search-bar 컴포넌트 내에서 기본값으로 지정해놓고 온보딩 등의 다른 페이지에서 텍스트를 변경하여 사용할 수 있도록 하였습니다.
ex) `<SearchBar placeholder="아티스트를 검색해주세요" />`
2. 온보딩 화면에서는 뒤로가기 아이콘이 보이지 않도록 조건부 렌더링 설정했씁니다.
3. 검색창에 focus 되면 바로 placeholder는 사라지고 전체 지우기 아이콘 뜨게 하였습니다.
4. 검색 완료 후에도 검색창에 텍스트 사라지지 않도록 수정했습니다.

## 📸 Screenshot


https://github.com/user-attachments/assets/bdc86d6d-3638-4212-ac19-7de6e6cb7662

### 뒤로가기 버튼이 없는 온보딩 뷰의 서치바 예시
![스크린샷 2025-03-18 080842](https://github.com/user-attachments/assets/dad70ef7-5746-4ddb-bee9-ce82380451b1)

