### PR TITLE
fix(design-system): Prettier 설정 추가 및 SVG 컴포넌트 수정

### DIFF
--- a/packages/design-system/.prettierrc
+++ b/packages/design-system/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/packages/design-system/src/icons/src/InfoOverlay.tsx
+++ b/packages/design-system/src/icons/src/InfoOverlay.tsx
@@ -5,7 +5,6 @@ const SvgInfoOverlay = (props: SVGProps<SVGSVGElement>) => (
     width="1em"
     height="1em"
     fill="none"
-    viewBox="0 0 300 200"
     {...props}
   >
     <path

--- a/packages/design-system/src/icons/src/SlideOverlayOp.tsx
+++ b/packages/design-system/src/icons/src/SlideOverlayOp.tsx
@@ -2,9 +2,9 @@ import type { SVGProps } from 'react';
 const SvgSlideOverlayOp = (props: SVGProps<SVGSVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
+    width="1em"
+    height="1em"
     fill="none"
-    viewBox="0 0 156 208"
-    preserveAspectRatio="none"
     {...props}
   >
     <path fill="#fff" fillOpacity={0.3} d="M0 0h156v208H0z" />


### PR DESCRIPTION
## 📌 Summary

- #347 

## 📚 Tasks

- design-system 내의 `.prettierrc` 파일 추가


## 👀 To Reviewer

svg 파일 하나를 추가하고 pnpm svgr 을하면 기존에는 import 문에 콘페티 prettier 설정이 적용되지 않아서 `""` 로 전부 따옴표가 변경되었어요 

하나만 추가해도 변경사항이 너무 많이 생겨서 불편함을 겪곤 했는데 그 문제를 해결하기 위해서 디자인 시스템 레포내에 prettierrc 파일을 두어서 svgr 을 사용해도 prettier 설정이 자동으로 적용되도록 하였어요

모노레포 구조에서 Prettier 가 설정 파일을 제대로 읽지 못했던 이유는 기본적으로 루트디렉토리 부터 설정 파일을 탐색하기 때문이에요.

모노레포에서 design-system 이라는 패키지가 독립적으로 관리되는 만큼 상위 디렉토리로 올라가면서 .prettierrc, prettier.config.js 같은 설정 파일을 찾는데, 

design-system 에는 .prettierrc, prettier.config.js 같은 설정 파일이 존재하지 않기 때문에 기본 설정을 사용해요.

그래서 디자인 시스템에서도 .prettierrc 를 만드는게 자연스러운 방식이라고 하더라구요.

---

추가로 궁금했던 점은 Ctrl + s 를 눌렀을때 디자인 시스템에서도 저희가 설정한 프리티어 설정이 문제없이 작동했잖아요. 왜 이 이벤트는 인식을 하는 걸까? 궁금했는데,

더 상위 개념인 VS Code 에서 프로젝트 루트를 기준으로 Prettier 설정을 자동 탐색했기 때문에  루트 디렉토리에 존재하는 `prettier.config.mjs` 파일을 인식하여 자동 포맷하고 있던거라고 합니다 ㅎㅎ

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요. 필요시 .gif 형식으로 첨부해주세요.
-->
