### PR TITLE
Fix(client): my 아티스트 조회 api url 수정 반영

### DIFF
--- a/apps/client/src/shared/apis/like/like.ts
+++ b/apps/client/src/shared/apis/like/like.ts
@@ -4,15 +4,11 @@ import { BaseResponseWithoutData } from '@shared/types/api';
 import { del, post } from '../config/instance';
 
 export const postLikeArtist = async (artistId: string): Promise<void> => {
-  await post<BaseResponseWithoutData>(
-    `${END_POINT.GET_FAVORITE_ARTISTS}/${artistId}`,
-  );
+  await post<BaseResponseWithoutData>(END_POINT.POST_LIKE_ARTIST(artistId));
 };
 
 export const deleteLikeArtist = async (artistId: string): Promise<void> => {
-  await del<BaseResponseWithoutData>(
-    `${END_POINT.GET_FAVORITE_ARTISTS}/${artistId}`,
-  );
+  await post<BaseResponseWithoutData>(END_POINT.POST_LIKE_ARTIST(artistId));
 };
 
 export const postLikeFestival = async (festivalId: number): Promise<void> => {

--- a/apps/client/src/shared/apis/like/like.ts
+++ b/apps/client/src/shared/apis/like/like.ts
@@ -8,7 +8,7 @@ export const postLikeArtist = async (artistId: string): Promise<void> => {
 };
 
 export const deleteLikeArtist = async (artistId: string): Promise<void> => {
-  await post<BaseResponseWithoutData>(END_POINT.POST_LIKE_ARTIST(artistId));
+  await del<BaseResponseWithoutData>(END_POINT.POST_LIKE_ARTIST(artistId));
 };
 
 export const postLikeFestival = async (festivalId: number): Promise<void> => {

--- a/apps/client/src/shared/apis/user/user.ts
+++ b/apps/client/src/shared/apis/user/user.ts
@@ -23,7 +23,7 @@ export const getMyArtists = async (): Promise<FavoriteArtistsResponses> => {
 
 export const getPerformances = async (): Promise<PerformanceResponse> => {
   const response = await get<BaseResponse<PerformanceResponse>>(
-    END_POINT.GET_PERFORMANCE_FAVORITE,
+    END_POINT.GET_FAVORITE_PERFORMANCES,
   );
   return response.data;
 };

--- a/apps/client/src/shared/constants/api.ts
+++ b/apps/client/src/shared/constants/api.ts
@@ -2,8 +2,8 @@ export const BASE_URL = import.meta.env.VITE_BASE_URL as string;
 
 export const END_POINT = {
   GET_USER_PROFILE: '/user/info',
-  GET_FAVORITE_ARTISTS: '/user/favorites/artists',
-  GET_FAVORITE_PERFORMANCES: '/user/favorites/performances',
+  GET_FAVORITE_ARTISTS: '/user/favorites/artists/preview',
+  GET_FAVORITE_PERFORMANCES: '/user/favorites/performances/preview',
   POST_LIKE_ARTIST: (artistId: string) => `/user/favorites/artists/${artistId}`,
   POST_LIKE_FESTIVAL: (festivalId: number) =>
     `/user/favorites/festivals/${festivalId}`,
@@ -26,7 +26,6 @@ export const END_POINT = {
     `/user/timetables/festivals/add${cursor ? `?cursor=${cursor}` : ''}`,
   DEL_FESTIVAL_TIMETABLES: (festivalId: number) =>
     `user/timetables/festivals/${festivalId}`,
-  GET_PERFORMANCE_FAVORITE: '/user/favorites/performances/preview',
   //로그인,로그아웃
   POST_SOCIAL_LOGIN: 'auth/login',
   POST_LOGOUT: 'auth/logout',


### PR DESCRIPTION
## 📌 Summary

- #347 

## 📚 Tasks

- my 아티스트 미리보기 목록 조회 api url 에 `preview` 가 추가되어서 반영하고, 
- 기존에 artist like post, delete END_POINT도 변경했습니다.

<!--
## 👀 To Reviewer

(기재 내용 없을 경우 섹션 삭제) 더 전달할 내용 혹은 리뷰에게 요청하는 내용을 작성해주세요.
-->

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요. 필요시 .gif 형식으로 첨부해주세요.
-->
