### PR TITLE
Feat(client): 온보딩 페이지 내 검색 플로우 구현

### DIFF
--- a/apps/client/src/pages/onboarding/components/artist-search.css.ts
+++ b/apps/client/src/pages/onboarding/components/artist-search.css.ts
@@ -11,8 +11,7 @@ export const searchBarContainer = style({
 });
 
 export const searchBarFrame = style({
-  display: 'flex',
-  alignItems: 'center',
+  ...themeVars.display.flexAlignCenter,
   width: '100%',
   gap: '0.5rem',
 });

--- a/apps/client/src/pages/onboarding/components/artist-search.css.ts
+++ b/apps/client/src/pages/onboarding/components/artist-search.css.ts
@@ -1,0 +1,30 @@
+import { style } from '@vanilla-extract/css';
+
+import { themeVars } from '@confeti/design-system/styles';
+
+export const searchBarContainer = style({
+  ...themeVars.display.flexJustifyAlignCenter,
+  padding: '0.8rem 2rem',
+  width: '100%',
+  gap: '0.8rem',
+  backgroundColor: themeVars.color.white,
+});
+
+export const searchBarFrame = style({
+  display: 'flex',
+  alignItems: 'center',
+  width: '100%',
+  gap: '0.5rem',
+});
+
+export const artistSearchContainer = style({
+  ...themeVars.display.flexAlignCenter,
+  justifyContent: 'center',
+  width: '100%',
+  height: '100dvh',
+});
+
+export const artistSearchDescription = style({
+  ...themeVars.fontStyles.body2_m_15,
+  color: themeVars.color.gray500,
+});

--- a/apps/client/src/pages/onboarding/components/artist-search.tsx
+++ b/apps/client/src/pages/onboarding/components/artist-search.tsx
@@ -2,8 +2,12 @@ import { SearchBar } from '@confeti/design-system';
 
 import * as styles from './artist-search.css';
 
-//TODO : 검색결과 length로 조건부 렌더링 로직 추가
-const ArtistSearch = () => {
+interface ArtistSearchProps {
+  handleArtistSelect: () => void;
+}
+
+//TODO : 검색결과 유무로 조건부 렌더링 로직 추가 및 아티스트 리스트 클릭 시 handleArtistSelect onClick전달
+const ArtistSearch = ({ handleArtistSelect }: ArtistSearchProps) => {
   return (
     <>
       <div className={styles.searchBarContainer}>

--- a/apps/client/src/pages/onboarding/components/artist-search.tsx
+++ b/apps/client/src/pages/onboarding/components/artist-search.tsx
@@ -2,12 +2,12 @@ import { SearchBar } from '@confeti/design-system';
 
 import * as styles from './artist-search.css';
 
-interface ArtistSearchProps {
-  handleArtistSelect: () => void;
-}
+// interface ArtistSearchProps {
+//   handleArtistSelect: () => void;
+// }
 
 //TODO : 검색결과 유무로 조건부 렌더링 로직 추가 및 아티스트 리스트 클릭 시 handleArtistSelect onClick전달
-const ArtistSearch = ({ handleArtistSelect }: ArtistSearchProps) => {
+const ArtistSearch = () => {
   return (
     <>
       <div className={styles.searchBarContainer}>

--- a/apps/client/src/pages/onboarding/components/artist-search.tsx
+++ b/apps/client/src/pages/onboarding/components/artist-search.tsx
@@ -1,0 +1,23 @@
+import { SearchBar } from '@confeti/design-system';
+
+import * as styles from './artist-search.css';
+
+//TODO : 검색결과 length로 조건부 렌더링 로직 추가
+const ArtistSearch = () => {
+  return (
+    <>
+      <div className={styles.searchBarContainer}>
+        <div className={styles.searchBarFrame}>
+          <SearchBar placeholder="아티스트 또는 공연을 검색해보세요!" />
+        </div>
+      </div>
+      <section className={styles.artistSearchContainer}>
+        <p className={styles.artistSearchDescription}>
+          선호하는 아티스트를 검색해보세요
+        </p>
+      </section>
+    </>
+  );
+};
+
+export default ArtistSearch;

--- a/apps/client/src/pages/onboarding/components/artist-select.tsx
+++ b/apps/client/src/pages/onboarding/components/artist-select.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 
 import { Avatar, Description, SearchBar } from '@confeti/design-system';
 
@@ -17,14 +18,18 @@ interface artistSelectProps {
 }
 
 const ArtistSelect = ({ children }: artistSelectProps) => {
-  const [isFocused, setIsFocused] = useState(false);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const isFocused = searchParams.get('search') === 'true';
 
-  const handleFocus = () => {
-    setIsFocused(true);
+  const handleSearchBarFocus = () => {
+    setSearchParams({ search: 'true' });
+  };
+  const handleArtistSelect = () => {
+    setSearchParams({});
   };
 
   if (isFocused) {
-    return <ArtistSearch />;
+    return <ArtistSearch handleArtistSelect={handleArtistSelect} />;
   } else {
     return (
       <section className={styles.onboardingContentSection}>
@@ -36,7 +41,7 @@ const ArtistSelect = ({ children }: artistSelectProps) => {
           <SearchBar
             showBackButton={false}
             placeholder="아티스트를 검색해주세요"
-            onFocus={handleFocus}
+            onFocus={handleSearchBarFocus}
           />
         </div>
         <div className={styles.avatarGridSection}>

--- a/apps/client/src/pages/onboarding/components/artist-select.tsx
+++ b/apps/client/src/pages/onboarding/components/artist-select.tsx
@@ -7,7 +7,7 @@ import ArtistSearch from './artist-search';
 
 import * as styles from './artist-select.css';
 //TODO: remove mock data
-const mockArtists = Array.from({ length: 100 }, (_, i) => ({
+const mockArtists = Array.from({ length: 20 }, (_, i) => ({
   id: i,
   name: `오아시스 ${i + 1}`,
   src: 'https://i.scdn.co/image/ab6761610000f1786a50f39b95ce98a0e6bf5b21',

--- a/apps/client/src/pages/onboarding/components/artist-select.tsx
+++ b/apps/client/src/pages/onboarding/components/artist-select.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from 'react';
+import { ReactNode } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { Avatar, Description, SearchBar } from '@confeti/design-system';

--- a/apps/client/src/pages/onboarding/components/artist-select.tsx
+++ b/apps/client/src/pages/onboarding/components/artist-select.tsx
@@ -24,12 +24,12 @@ const ArtistSelect = ({ children }: artistSelectProps) => {
   const handleSearchBarFocus = () => {
     setSearchParams({ search: 'true' });
   };
-  const handleArtistSelect = () => {
-    setSearchParams({});
-  };
+  // const handleArtistSelect = () => {
+  //   setSearchParams({});
+  // };
 
   if (isFocused) {
-    return <ArtistSearch handleArtistSelect={handleArtistSelect} />;
+    return <ArtistSearch />;
   } else {
     return (
       <section className={styles.onboardingContentSection}>

--- a/apps/client/src/pages/onboarding/components/artist-select.tsx
+++ b/apps/client/src/pages/onboarding/components/artist-select.tsx
@@ -1,9 +1,10 @@
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 
 import { Avatar, Description, SearchBar } from '@confeti/design-system';
 
-import * as styles from './artist-select.css';
+import ArtistSearch from './artist-search';
 
+import * as styles from './artist-select.css';
 //TODO: remove mock data
 const mockArtists = Array.from({ length: 100 }, (_, i) => ({
   id: i,
@@ -16,29 +17,44 @@ interface artistSelectProps {
 }
 
 const ArtistSelect = ({ children }: artistSelectProps) => {
-  return (
-    <section className={styles.onboardingContentSection}>
-      <Description
-        descriptionText={'선호하는 아티스트를\n모두 선택해주세요'}
-        fontSize={20}
-      />
-      <div className={styles.searchBarSection}>
-        <SearchBar
-          showBackButton={false}
-          placeholder="아티스트를 검색해주세요"
+  const [isFocused, setIsFocused] = useState(false);
+
+  const handleFocus = () => {
+    setIsFocused(true);
+  };
+
+  if (isFocused) {
+    return <ArtistSearch />;
+  } else {
+    return (
+      <section className={styles.onboardingContentSection}>
+        <Description
+          descriptionText={'선호하는 아티스트를\n모두 선택해주세요'}
+          fontSize={20}
         />
-      </div>
-      <div className={styles.avatarGridSection}>
-        {mockArtists.map((artist) => (
-          <div key={artist.id} className={styles.avatar}>
-            <Avatar size="xl" src={artist.src} alt={`${artist.name} 이미지`} />
-            <p className={styles.artistName}>{artist.name}</p>
-          </div>
-        ))}
-      </div>
-      {children}
-    </section>
-  );
+        <div className={styles.searchBarSection}>
+          <SearchBar
+            showBackButton={false}
+            placeholder="아티스트를 검색해주세요"
+            onFocus={handleFocus}
+          />
+        </div>
+        <div className={styles.avatarGridSection}>
+          {mockArtists.map((artist) => (
+            <div key={artist.id} className={styles.avatar}>
+              <Avatar
+                size="xl"
+                src={artist.src}
+                alt={`${artist.name} 이미지`}
+              />
+              <p className={styles.artistName}>{artist.name}</p>
+            </div>
+          ))}
+        </div>
+        {children}
+      </section>
+    );
+  }
 };
 
 export default ArtistSelect;

--- a/apps/client/src/pages/onboarding/components/onboarding-complete.tsx
+++ b/apps/client/src/pages/onboarding/components/onboarding-complete.tsx
@@ -28,7 +28,7 @@ const OnBoardingComplete = ({ children }: OnBoardingCompleteProps) => {
   useEffect(() => {
     const timers = [
       setTimeout(() => setPhase('description'), 3000),
-      setTimeout(() => setPhase('cta'), 6000),
+      setTimeout(() => setPhase('cta'), 5500),
     ];
     return () => timers.forEach(clearTimeout);
   }, []);

--- a/apps/client/src/pages/onboarding/components/onboarding-complete.tsx
+++ b/apps/client/src/pages/onboarding/components/onboarding-complete.tsx
@@ -86,7 +86,7 @@ const OnBoardingComplete = ({ children }: OnBoardingCompleteProps) => {
               <motion.div
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: 0.6 }}
+                transition={{ duration: 1, delay: 0.6 }}
               >
                 <Description
                   descriptionText={
@@ -100,7 +100,7 @@ const OnBoardingComplete = ({ children }: OnBoardingCompleteProps) => {
                 className={styles.confetiLogo}
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: 0.4 }}
+                transition={{ duration: 0.8, delay: 0.4 }}
               >
                 <SvgConfeti3DLogo21 width={'22rem'} height={'22rem'} />
               </motion.div>
@@ -108,7 +108,7 @@ const OnBoardingComplete = ({ children }: OnBoardingCompleteProps) => {
               <motion.div
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.5, delay: 0.5 }}
+                transition={{ duration: 0.8, delay: 0.5 }}
               >
                 {children}
               </motion.div>

--- a/apps/client/src/pages/onboarding/components/onboarding-complete.tsx
+++ b/apps/client/src/pages/onboarding/components/onboarding-complete.tsx
@@ -33,6 +33,7 @@ const OnBoardingComplete = ({ children }: OnBoardingCompleteProps) => {
     return () => timers.forEach(clearTimeout);
   }, []);
 
+  //TODO : motion.div 컴포넌트화 진행
   const renderPhase = () => {
     switch (phase) {
       case 'loading':

--- a/apps/client/src/pages/onboarding/components/onboarding-complete.tsx
+++ b/apps/client/src/pages/onboarding/components/onboarding-complete.tsx
@@ -82,18 +82,35 @@ const OnBoardingComplete = ({ children }: OnBoardingCompleteProps) => {
             <section
               className={styles.completeContentSection({ phase: 'cta' })}
             >
-              <div>
+              <motion.div
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6, delay: 0.6 }}
+              >
                 <Description
                   descriptionText={
                     '멋진 취향이네요!\n선택하신 아티스트의 공연 소식을\n빠르게 알려드릴게요.'
                   }
                   fontSize={20}
                 />
-              </div>
-              <div className={styles.confetiLogo}>
+              </motion.div>
+
+              <motion.div
+                className={styles.confetiLogo}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6, delay: 0.4 }}
+              >
                 <SvgConfeti3DLogo21 width={'22rem'} height={'22rem'} />
-              </div>
-              <div>{children}</div>
+              </motion.div>
+
+              <motion.div
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.5, delay: 0.5 }}
+              >
+                {children}
+              </motion.div>
             </section>
           </motion.div>
         );

--- a/packages/design-system/src/components/avatar/avatar.css.ts
+++ b/packages/design-system/src/components/avatar/avatar.css.ts
@@ -82,6 +82,7 @@ export const imgVariants = recipe({
     height: '100%',
     borderRadius: '100%',
     objectFit: 'cover',
+    cursor: 'pointer',
   },
 });
 

--- a/packages/design-system/src/components/description/description.css.ts
+++ b/packages/design-system/src/components/description/description.css.ts
@@ -1,4 +1,3 @@
-import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
 import { themeVars } from '../../styles';

--- a/packages/design-system/src/components/description/description.css.ts
+++ b/packages/design-system/src/components/description/description.css.ts
@@ -4,6 +4,7 @@ import { themeVars } from '../../styles';
 
 export const descriptionTextVariants = recipe({
   base: {
+    width: '100%',
     whiteSpace: 'pre-line',
   },
   variants: {

--- a/packages/design-system/src/components/description/description.css.ts
+++ b/packages/design-system/src/components/description/description.css.ts
@@ -20,11 +20,3 @@ export const descriptionTextVariants = recipe({
     },
   },
 });
-
-export const descriptioncontainer = style({
-  ...themeVars.display.flexColumn,
-  width: '100%',
-  padding: '2rem 2rem 0rem 2rem',
-  gap: '1rem',
-  alignSelf: 'stretch',
-});


### PR DESCRIPTION
## 📌 Summary

- #376 

## 📚 Tasks

- 사용되지 않는 import 혹은 style 파일을 삭제했습니다.
- 애니메이션의 디테일을 수정
- 검색 플로우 구현
- 조건부 렌더링 로직


## 👀 To Reviewer

step 2의 애니메이션을 수정했으나, 더 자세한 요구사항은 QA기간에 반영하겠습니다 

초기에는 useState의 true , false 값으로 ArtistSearch 컴포넌트를 조건부 렌더링 하였으나, 

문제가 발생했어요. SeachBar 컴포넌트에서 사용되는 back 버튼의 기본 동작인 navigate(-1) 이 동작하지 않았는데, 이유는 ArtistSelect 와 ArtistSearch 은 같은 url 값을 갖기 때문에, -1 이 요구대로 동작하지 않았던 거였는데요, 

`?search=true` 쿼리로 url 을 분기하게끔 하였습니다. 쿼리 스트링을 이용해서 총 2가지 문제를 해결할 수 있었는데요,

한 가지는 말씀드린 navigate 동작이고, 한 가지는 사용자가 ArtistSearch 에서 새로고침을 할 경우 상태값이 초기화 되면서 ArtistSelect 컴포넌트로 리렌더링 되는 현상이였습니다. 

남은 작업은 아티스트 정보를 불러오고, post api를 연동하고, 검색 api 를 연동하는 작업입니다.

## 📸 Screenshot

https://github.com/user-attachments/assets/08fda1b1-1cb0-4b33-99e0-58148b177044


