### PR TITLE
Feat(client): My artist 전체 목록 조회 API 연결

### DIFF
--- a/apps/client/src/pages/my/components/artist/artist-list.tsx
+++ b/apps/client/src/pages/my/components/artist/artist-list.tsx
@@ -1,22 +1,16 @@
 import { Avatar, LikeButton } from '@confeti/design-system';
 import { useLikeMutation } from '@shared/hooks/use-like-mutation';
+import { MyArtists } from '@shared/types/user-response';
 import { checkIsNotLoggedIn } from '@shared/utils/check-is-not-logged-in';
+import { getAddedDate } from '@shared/utils/format-date';
 
 import * as styles from './artist-list.css';
 
-// TODO: API 명세서 나오면 실제 타입으로 변경
-interface Artist {
-  artistId: string;
-  name: string;
-  profileUrl: string;
-  addedDate?: string;
+interface Props {
+  artists: MyArtists[];
 }
 
-interface ArtistListProps {
-  artists: Artist[];
-}
-
-const ArtistList = ({ artists }: ArtistListProps) => {
+const ArtistList = ({ artists }: Props) => {
   const { mutate } = useLikeMutation();
 
   const handleLike = (artistId: string, action: 'LIKE' | 'UNLIKE') => {
@@ -31,15 +25,13 @@ const ArtistList = ({ artists }: ArtistListProps) => {
             <Avatar size="sm" src={artist.profileUrl} alt={artist.name} />
             <div className={styles.info}>
               <p className={styles.title}>{artist.name}</p>
-              {/* TODO: 명세서 나오면 데이터 변경 */}
-              <p className={styles.date}>{artist.addedDate || '최근 추가됨'}</p>
+              <p className={styles.date}>{getAddedDate(artist.createdAt)}</p>
             </div>
           </div>
 
           <LikeButton
             className={styles.likeButton}
-            // TODO: 좋아요 여부 API 연결 후 변경
-            isFavorite={true}
+            isFavorite={artist.isFavorite}
             onLikeToggle={(action) => handleLike(artist.artistId, action)}
             isLoggedIn={!checkIsNotLoggedIn()}
           />

--- a/apps/client/src/pages/my/hooks/use-my-favorites.ts
+++ b/apps/client/src/pages/my/hooks/use-my-favorites.ts
@@ -1,7 +1,10 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 
 import { USER_QUERY_OPTIONS } from '@shared/apis/user/user-queries';
-import { PerformancesFilterType } from '@shared/types/user-response';
+import {
+  ArtistSortType,
+  PerformancesFilterType,
+} from '@shared/types/user-response';
 import { checkIsNotLoggedIn } from '@shared/utils/check-is-not-logged-in';
 
 export const useMyArtistPreview = () => {
@@ -31,10 +34,16 @@ export const useMyUpcomingPerformance = () => {
   return { data };
 };
 
+export const useMyArtist = (sortBy: ArtistSortType) => {
+  const { data } = useSuspenseQuery({
+    ...USER_QUERY_OPTIONS.MY_ARTISTS(sortBy),
+  });
+  return { data };
+};
+
 export const useMyPerformances = (performancesType: PerformancesFilterType) => {
   const { data } = useQuery({
     ...USER_QUERY_OPTIONS.MY_PERFORMANCES(performancesType),
   });
-
   return { data };
 };

--- a/apps/client/src/pages/my/hooks/use-my-favorites.ts
+++ b/apps/client/src/pages/my/hooks/use-my-favorites.ts
@@ -28,8 +28,10 @@ export const useMyPerformancePreview = () => {
 };
 
 export const useMyUpcomingPerformance = () => {
+  const isNotLoggedIn = checkIsNotLoggedIn();
   const { data } = useQuery({
     ...USER_QUERY_OPTIONS.MY_UPCOMING_PERFORMANCE(),
+    enabled: !isNotLoggedIn,
   });
   return { data };
 };
@@ -42,7 +44,7 @@ export const useMyArtist = (sortBy: ArtistSortType) => {
 };
 
 export const useMyPerformances = (performancesType: PerformancesFilterType) => {
-  const { data } = useQuery({
+  const { data } = useSuspenseQuery({
     ...USER_QUERY_OPTIONS.MY_PERFORMANCES(performancesType),
   });
   return { data };

--- a/apps/client/src/pages/my/page/artist/artist-more.tsx
+++ b/apps/client/src/pages/my/page/artist/artist-more.tsx
@@ -1,39 +1,35 @@
 import { useState } from 'react';
 import ArtistList from '@pages/my/components/artist/artist-list';
-import { useMyArtistPreview } from '@pages/my/hooks/use-my-favorites';
+import { useMyArtist } from '@pages/my/hooks/use-my-favorites';
 
 import { Header } from '@confeti/design-system';
 import { IcSwitch } from '@confeti/design-system/icons';
-import { ARTISTS_DATA } from '@shared/mocks/artists-data';
+import { ArtistSortType } from '@shared/types/user-response';
 
 import * as styles from './artist-more.css';
 
 const ArtistMore = () => {
-  const { data } = useMyArtistPreview();
-  const [sortOption, setSortOption] = useState<'latest' | 'name'>('latest');
-
-  if (!data) return null;
-
-  // TODO: API 데이터 연결 (ARTISTS_DATA 제거)
-  const allArtists = [...ARTISTS_DATA.artists, ...data.artists];
-  const artistsCount = allArtists.length;
+  const [sortOption, setSortOption] = useState<ArtistSortType>('createdAt');
+  const { data } = useMyArtist(sortOption);
 
   const toggleSort = () => {
-    setSortOption((prev) => (prev === 'latest' ? 'name' : 'latest'));
+    setSortOption((prev) =>
+      prev === 'createdAt' ? 'alphabetically' : 'createdAt',
+    );
   };
 
   return (
     <>
       <Header variant="detail" title="My Artist" />
       <div className={styles.header}>
-        <p>전체 {artistsCount}</p>
+        <p>전체 {data.artistCount}</p>
         <button className={styles.sort} onClick={toggleSort}>
-          <p>{sortOption === 'latest' ? '최근추가순' : '가나다순'}</p>
+          <p>{sortOption === 'createdAt' ? '최근추가순' : '가나다순'}</p>
           <IcSwitch width={'1.6rem'} height={'1.6rem'} />
         </button>
       </div>
 
-      <ArtistList artists={allArtists} />
+      <ArtistList artists={data.artists} />
     </>
   );
 };

--- a/apps/client/src/pages/my/page/performance/performance-more.tsx
+++ b/apps/client/src/pages/my/page/performance/performance-more.tsx
@@ -20,7 +20,6 @@ const ConfetiMore = () => {
         return 'ALL';
     }
   }, [selectedCategory]);
-
   const { data } = useMyPerformances(filterType);
 
   return (
@@ -39,7 +38,7 @@ const ConfetiMore = () => {
           ))}
         </ul>
       </nav>
-      <PerformanceList performances={data?.performances ?? []} />
+      <PerformanceList performances={data.performances ?? []} />
       <Footer />
     </>
   );

--- a/apps/client/src/pages/my/page/profile/my-profile.tsx
+++ b/apps/client/src/pages/my/page/profile/my-profile.tsx
@@ -8,6 +8,7 @@ import UserInfo from '@pages/my/components/profile/user-info';
 import NoUpcomingPerformanceSection from '@pages/my/components/upcoming-performance/no-upcoming-performance-section';
 import UpcomingPerformanceSection from '@pages/my/components/upcoming-performance/upcoming-performance-section';
 import {
+  useMyArtistPreview,
   useMyPerformancePreview,
   useMyUpcomingPerformance,
 } from '@pages/my/hooks/use-my-favorites';
@@ -15,17 +16,13 @@ import { useUserProfile } from '@pages/my/hooks/use-user-info';
 
 import { Box, Footer, Header } from '@confeti/design-system';
 import { routePath } from '@shared/constants/path';
-import { ARTISTS_DATA } from '@shared/mocks/artists-data';
 
 const MyProfile = () => {
   const navigate = useNavigate();
   const { data: profileData } = useUserProfile();
   const { data: upcomingPerformanceData } = useMyUpcomingPerformance();
+  const { data: artistData } = useMyArtistPreview();
   const { data: performanceData } = useMyPerformancePreview();
-
-  // TODO: API 데이터 연결 (ARTISTS_DATA 제거)
-  // const { data: artistData } = useMyArtist();
-  const artistData = ARTISTS_DATA;
 
   if (!profileData || !artistData || !performanceData) {
     return null;

--- a/apps/client/src/shared/apis/user/user-queries.ts
+++ b/apps/client/src/shared/apis/user/user-queries.ts
@@ -1,7 +1,11 @@
 import { queryOptions } from '@tanstack/react-query';
 
-import { PerformancesFilterType } from './../../types/user-response';
 import {
+  ArtistSortType,
+  PerformancesFilterType,
+} from './../../types/user-response';
+import {
+  getMyArtists,
   getMyArtistsPreview,
   getMyPerformances,
   getMyPerformancesPreview,
@@ -41,6 +45,11 @@ export const USER_QUERY_OPTIONS = {
     queryOptions({
       queryKey: USER_QUERY_KEY.MY_UPCOMING_PERFORMANCE(),
       queryFn: getMyUpcomingPerformance,
+    }),
+  MY_ARTISTS: (sortBy: ArtistSortType) =>
+    queryOptions({
+      queryKey: [USER_QUERY_KEY.MY_ARTISTS(), sortBy],
+      queryFn: () => getMyArtists(sortBy),
     }),
   MY_PERFORMANCES: (performancesType: PerformancesFilterType) =>
     queryOptions({

--- a/apps/client/src/shared/apis/user/user.ts
+++ b/apps/client/src/shared/apis/user/user.ts
@@ -2,7 +2,9 @@ import { get } from '@shared/apis/config/instance';
 import { END_POINT } from '@shared/constants/api';
 import { BaseResponse } from '@shared/types/api';
 import {
+  ArtistSortType,
   FavoriteArtistsResponses,
+  MyArtistsResponse,
   MyPerformancesResponse,
   MyUpcomingPerformance,
   PerformanceResponse,
@@ -40,6 +42,15 @@ export const getMyUpcomingPerformance =
     );
     return response.data;
   };
+
+export const getMyArtists = async (
+  sortBy: ArtistSortType,
+): Promise<MyArtistsResponse> => {
+  const response = await get<BaseResponse<MyArtistsResponse>>(
+    END_POINT.GET_MY_ARTISTS(sortBy),
+  );
+  return response.data;
+};
 
 export const getMyPerformances = async (
   performancesType: PerformancesFilterType,

--- a/apps/client/src/shared/constants/api.ts
+++ b/apps/client/src/shared/constants/api.ts
@@ -5,6 +5,8 @@ export const END_POINT = {
   GET_MY_UPCOMING_PERFORMANCE: '/user/favorites/performance',
   GET_MY_ARTISTS_PREVIEW: '/user/favorites/artists/preview',
   GET_MY_PERFORMANCES_PREVIEW: '/user/favorites/performances/preview',
+  GET_MY_ARTISTS: (sortBy: 'createdAt' | 'alphabetically') =>
+    `/user/favorites/artists?sortBy=${sortBy}`,
   GET_MY_PERFORMANCES: (performancesType: 'FESTIVAL' | 'CONCERT' | 'ALL') =>
     `user/favorites/performances?type=${performancesType}`,
 

--- a/apps/client/src/shared/types/user-response.ts
+++ b/apps/client/src/shared/types/user-response.ts
@@ -11,11 +11,23 @@ export interface Artists {
   profileUrl: string;
 }
 
+export interface MyArtists extends Artists {
+  createdAt: string;
+  isFavorite: boolean;
+}
+
+export interface MyArtistsResponse {
+  artists: MyArtists[];
+  artistCount: number;
+}
+
 export interface FavoriteArtistsResponses {
   artists: Artists[];
 }
 
 export type PerformancesFilterType = 'FESTIVAL' | 'CONCERT' | 'ALL';
+
+export type ArtistSortType = 'createdAt' | 'alphabetically';
 
 export interface Performance {
   index: number;

--- a/apps/client/src/shared/utils/format-date.ts
+++ b/apps/client/src/shared/utils/format-date.ts
@@ -101,3 +101,23 @@ export const formatDate = (
       return `${year}.${month}.${day}`;
   }
 };
+
+/**
+ * 아티스트가 추가된 날짜를 기준으로 "오늘 추가됨" 또는 "N일 전 추가됨" 형식의 문자열을 반환합니다.
+ *
+ * @param {string} createdAt - ISO 형식의 날짜 문자열 (예: "2025-04-20T23:28:30")
+ * @returns {string} - 포맷된 날짜 정보 (예: "오늘 추가됨", "2일 전 추가됨")
+ */
+export const getAddedDate = (createdAt: string): string => {
+  const createdDate = new Date(createdAt);
+  const now = new Date();
+
+  const diffTime = now.getTime() - createdDate.getTime();
+  const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) {
+    return '오늘 추가됨';
+  }
+
+  return `${diffDays}일 전 추가됨`;
+};

--- a/packages/design-system/src/components/like-button/like-button.css.ts
+++ b/packages/design-system/src/components/like-button/like-button.css.ts
@@ -16,11 +16,15 @@ export const likeButtonVariants = recipe({
   variants: {
     liked: {
       true: {
-        animation: `${heartAnimation} 0.3s ease-in-out`,
         fill: '#FB0D0D',
       },
       false: {
         fill: '#93959D',
+      },
+    },
+    animate: {
+      true: {
+        animation: `${heartAnimation} 0.3s ease-in-out`,
       },
     },
   },

--- a/packages/design-system/src/components/like-button/like-button.tsx
+++ b/packages/design-system/src/components/like-button/like-button.tsx
@@ -23,10 +23,6 @@ const LikeButton = ({
   const [liked, setLiked] = useState(isFavorite);
   const [animate, setAnimate] = useState(false);
 
-  useEffect(() => {
-    setLiked(isFavorite);
-  }, [isFavorite]);
-
   const handleClick = () => {
     if (!isLoggedIn) {
       toast('로그인 후 이용 가능해요');

--- a/packages/design-system/src/components/like-button/like-button.tsx
+++ b/packages/design-system/src/components/like-button/like-button.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { toast } from '@confeti/design-system';
 import { BtnHeart } from '@confeti/design-system/icons';

--- a/packages/design-system/src/components/like-button/like-button.tsx
+++ b/packages/design-system/src/components/like-button/like-button.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { toast } from '@confeti/design-system';
 import { BtnHeart } from '@confeti/design-system/icons';
@@ -21,6 +21,11 @@ const LikeButton = ({
   isLoggedIn = true,
 }: props) => {
   const [liked, setLiked] = useState(isFavorite);
+  const [animate, setAnimate] = useState(false);
+
+  useEffect(() => {
+    setLiked(isFavorite);
+  }, [isFavorite]);
 
   const handleClick = () => {
     if (!isLoggedIn) {
@@ -29,15 +34,25 @@ const LikeButton = ({
     }
 
     const newAction = liked ? 'UNLIKE' : 'LIKE';
+
+    if (!liked) {
+      setAnimate(true);
+    }
+
     setLiked(!liked);
     onLikeToggle(newAction);
+  };
+
+  const handleAnimationEnd = () => {
+    setAnimate(false);
   };
 
   return (
     <BtnHeart
       isFavorite={liked}
-      className={cn(likeButtonVariants({ liked }), className)}
+      className={cn(likeButtonVariants({ liked, animate }), className)}
       onClick={handleClick}
+      onAnimationEnd={handleAnimationEnd}
     />
   );
 };


### PR DESCRIPTION
## 📌 Summary

> - #391 

My artist 전체 목록 조회 API를 연결했어요.

## 📚 Tasks

- My artist 전체 목록 조회 API 연결
- 아티스트 추가 날짜를 포맷하는 유틸함수 추가
- 좋아요 버튼 개선

## 👀 To Reviewer
기존에는 좋아요버튼 애니메이션(scale transform)이 초기 페이지 렌더링시에도 적용이됐어요.
딱히 상관이 없을 것 같아서 그냥 두었는데, 아티스트 목록에 정렬 기능이 생기고나니 정렬이 된 컴포넌트의 좋아요 버튼만 DOM에서 수정되어 애니메이션이 적용되는 현상이 발생했습니다... 매우 어색하더라구요.
그래서 렌더링마다 애니메이션이 발생하는 대신 '좋아요' 클릭 시에만 애니메이션이 실행되도록 별도의 animate 상태 값을 추가하고, CSS에서 애니메이션 속성을 liked 상태와 분리하여 animate가 true일 때만 애니메이션이 적용되도록 변경했어요.



## 📸 Screenshot
<img width="369" alt="스크린샷 2025-04-21 오전 12 15 02" src="https://github.com/user-attachments/assets/e12ba2da-bade-4055-b50b-77b07cfb5668" />

<img width="369" alt="스크린샷 2025-04-21 오전 12 15 05" src="https://github.com/user-attachments/assets/c01fe5b2-fe1a-4313-8645-90b81ef96a14" />

