### PR TITLE
Feat(client): 로그인 여부에 따른 API 호출 방식 수정

### DIFF
--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -10,13 +10,14 @@ import {
   ToastContainer,
 } from '@confeti/design-system';
 import { rootStyle } from '@confeti/design-system/styles';
+import { CONFIG } from '@shared/constants/api';
 import Router from '@shared/router/router';
 
 import { queryClient } from './shared/utils/query-client';
 
-init(import.meta.env.VITE_AMPLITUDE_API_KEY);
+init(CONFIG.AMPLITUDE_API_KEY);
 Sentry.init({
-  dsn: import.meta.env.VITE_SENTRY_DSN,
+  dsn: CONFIG.SENTRY_DSN,
   tracePropagationTargets: ['localhost', /^https:\/\/confeti\.co\.kr/],
   tracesSampleRate: 1.0,
   normalizeDepth: 6,

--- a/apps/client/src/pages/home/page/home.tsx
+++ b/apps/client/src/pages/home/page/home.tsx
@@ -48,7 +48,6 @@ const Home = () => {
   const imageUrls = [ImgDday01, ImgDday02, ImgDday03, ImgDday04, ImgDday05];
 
   const { mutate: login } = useSocialLoginMutation();
-  const kakaoRedirectUrl = CONFIG.KAKAO_REDIRECT_URI;
   const params = new URLSearchParams(window.location.search);
   const code = params.get('code');
 
@@ -56,7 +55,7 @@ const Home = () => {
     if (code) {
       login({
         provider: 'KAKAO',
-        redirectUrl: kakaoRedirectUrl,
+        redirectUrl: CONFIG.KAKAO_REDIRECT_URI,
         code,
       });
     }

--- a/apps/client/src/pages/home/page/home.tsx
+++ b/apps/client/src/pages/home/page/home.tsx
@@ -8,6 +8,7 @@ import {
   TicketingCard,
 } from '@confeti/design-system';
 import NavigationTabs from '@shared/components/navigation-tabs';
+import { CONFIG } from '@shared/constants/api';
 import { useNavigateToDetail } from '@shared/hooks/use-navigate-to-detail';
 import { formatDate } from '@shared/utils/format-date';
 
@@ -47,7 +48,7 @@ const Home = () => {
   const imageUrls = [ImgDday01, ImgDday02, ImgDday03, ImgDday04, ImgDday05];
 
   const { mutate: login } = useSocialLoginMutation();
-  const kakaoRedirectUrl = import.meta.env.VITE_KAKAO_REDIRECT_URI;
+  const kakaoRedirectUrl = CONFIG.KAKAO_REDIRECT_URI;
   const params = new URLSearchParams(window.location.search);
   const code = params.get('code');
 

--- a/apps/client/src/pages/login/hooks/use-social-login-mutation.ts
+++ b/apps/client/src/pages/login/hooks/use-social-login-mutation.ts
@@ -11,7 +11,7 @@ export const useSocialLoginMutation = () => {
   const navigate = useNavigate();
 
   return useMutation<BaseResponse<SocialLoginResponse>, Error, KakaoLogin>({
-    mutationFn: (socialLoginResponse) => postSocialLogin(socialLoginResponse),
+    mutationFn: (socialLoginData) => postSocialLogin(socialLoginData),
     onSuccess: (data) => {
       if (data?.data) {
         const { accessToken, refreshToken, isOnboarding } = data.data;

--- a/apps/client/src/pages/login/page/login.tsx
+++ b/apps/client/src/pages/login/page/login.tsx
@@ -7,6 +7,7 @@ import {
   IcKakao,
   ImgTypelogoBig,
 } from '@confeti/design-system/icons';
+import { CONFIG } from '@shared/constants/api';
 import { routePath } from '@shared/constants/path';
 
 import * as styles from './login.css';
@@ -61,7 +62,7 @@ const processLine = (
 
 const handleLogin = (socialUrl: string) => {
   if (socialUrl === 'kakao') {
-    window.location.href = import.meta.env.VITE_KAKAO_URI;
+    window.location.href = CONFIG.KAKAO_URI;
   }
 };
 

--- a/apps/client/src/pages/my/components/profile/logout-section.tsx
+++ b/apps/client/src/pages/my/components/profile/logout-section.tsx
@@ -35,7 +35,10 @@ const LogoutSection = () => {
       <LogoutDialog
         isOpen={isOpen}
         onClose={close}
-        onConfirm={() => logout()}
+        onConfirm={() => {
+          logout();
+          close();
+        }}
       />
     ));
   };

--- a/apps/client/src/pages/my/hooks/use-logout.ts
+++ b/apps/client/src/pages/my/hooks/use-logout.ts
@@ -14,7 +14,7 @@ export const useLogoutMutation = () => {
   return useMutation<BaseResponse<void>, Error>({
     mutationFn: postLogout,
     onSuccess: () => {
-      queryClient.invalidateQueries({
+      queryClient.removeQueries({
         queryKey: [...USER_QUERY_KEY.PROFILE()],
       });
       authTokenHandler('remove');

--- a/apps/client/src/shared/apis/auth/auth.ts
+++ b/apps/client/src/shared/apis/auth/auth.ts
@@ -1,14 +1,27 @@
-import { END_POINT } from '@shared/constants/api';
+import { BASE_URL, END_POINT } from '@shared/constants/api';
 import { BaseResponse } from '@shared/types/api';
 import { KakaoLogin, SocialLoginResponse } from '@shared/types/login-response';
 
-import { axiosPublicInstance, del, post } from '../config/instance';
+import { del, post } from '../config/instance';
 
-export const postSocialLogin = async (socialLoginResponse: KakaoLogin) => {
-  const response = await axiosPublicInstance.post<
-    BaseResponse<SocialLoginResponse>
-  >(END_POINT.POST_SOCIAL_LOGIN, socialLoginResponse);
-  return response.data;
+export const postSocialLogin = async (
+  socialLoginData: KakaoLogin,
+): Promise<BaseResponse<SocialLoginResponse>> => {
+  const response = await fetch(`${BASE_URL}${END_POINT.POST_SOCIAL_LOGIN}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(socialLoginData),
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(`Error: ${response.status} - ${error.message}`);
+  }
+
+  const data = await response.json();
+  return data;
 };
 
 export const postLogout = async (): Promise<BaseResponse<void>> => {

--- a/apps/client/src/shared/apis/auth/auth.ts
+++ b/apps/client/src/shared/apis/auth/auth.ts
@@ -1,4 +1,4 @@
-import { BASE_URL, END_POINT } from '@shared/constants/api';
+import { CONFIG, END_POINT } from '@shared/constants/api';
 import { BaseResponse } from '@shared/types/api';
 import { KakaoLogin, SocialLoginResponse } from '@shared/types/login-response';
 
@@ -7,13 +7,16 @@ import { del, post } from '../config/instance';
 export const postSocialLogin = async (
   socialLoginData: KakaoLogin,
 ): Promise<BaseResponse<SocialLoginResponse>> => {
-  const response = await fetch(`${BASE_URL}${END_POINT.POST_SOCIAL_LOGIN}`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
+  const response = await fetch(
+    `${CONFIG.BASE_URL}${END_POINT.POST_SOCIAL_LOGIN}`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(socialLoginData),
     },
-    body: JSON.stringify(socialLoginData),
-  });
+  );
 
   if (!response.ok) {
     const error = await response.json();

--- a/apps/client/src/shared/apis/carousel/performances.ts
+++ b/apps/client/src/shared/apis/carousel/performances.ts
@@ -2,11 +2,11 @@ import { END_POINT } from '@shared/constants/api';
 import { BaseResponse } from '@shared/types/api';
 import { PerformanceResponse } from '@shared/types/performance-response';
 
-import { axiosPublicInstance } from '../config/instance';
+import { get } from '../config/instance';
 
 export const getLatestPerformances = async (): Promise<PerformanceResponse> => {
-  const response = await axiosPublicInstance.get<
-    BaseResponse<PerformanceResponse>
-  >(END_POINT.GET_LATEST_PERFORMANCES);
-  return response.data.data;
+  const response = await get<BaseResponse<PerformanceResponse>>(
+    END_POINT.GET_LATEST_PERFORMANCES,
+  );
+  return response.data;
 };

--- a/apps/client/src/shared/apis/carousel/ticketing.ts
+++ b/apps/client/src/shared/apis/carousel/ticketing.ts
@@ -2,11 +2,11 @@ import { END_POINT } from '@shared/constants/api';
 import { BaseResponse } from '@shared/types/api';
 import { TicketingResponse } from '@shared/types/ticketing-response';
 
-import { axiosPublicInstance } from '../config/instance';
+import { get } from '../config/instance';
 
 export const getTicketing = async (): Promise<TicketingResponse> => {
-  const response = await axiosPublicInstance.get<
-    BaseResponse<TicketingResponse>
-  >(END_POINT.GET_TICKETING);
-  return response.data.data;
+  const response = await get<BaseResponse<TicketingResponse>>(
+    END_POINT.GET_TICKETING,
+  );
+  return response.data;
 };

--- a/apps/client/src/shared/apis/confeti-detail/performance.ts
+++ b/apps/client/src/shared/apis/confeti-detail/performance.ts
@@ -3,22 +3,22 @@ import { BaseResponse } from '@shared/types/api';
 import { ConcertDetailResponse } from '@shared/types/concert-response';
 import { FestivalDetailResponse } from '@shared/types/festival-response';
 
-import { axiosPublicInstance } from '../config/instance';
+import { get } from '../config/instance';
 
 export const getConcertDetail = async (
   concertId: number,
 ): Promise<ConcertDetailResponse> => {
-  const response = await axiosPublicInstance.get<
-    BaseResponse<ConcertDetailResponse>
-  >(`${END_POINT.GET_CONCERT_DETAIL}/${concertId}`);
-  return response.data.data;
+  const response = await get<BaseResponse<ConcertDetailResponse>>(
+    `${END_POINT.GET_CONCERT_DETAIL}/${concertId}`,
+  );
+  return response.data;
 };
 
 export const getFestivalDetail = async (
   festivalId: number,
 ): Promise<FestivalDetailResponse> => {
-  const response = await axiosPublicInstance.get<
-    BaseResponse<FestivalDetailResponse>
-  >(`${END_POINT.GET_FESTIVAL_DETAIL}/${festivalId}`);
-  return response.data.data;
+  const response = await get<BaseResponse<FestivalDetailResponse>>(
+    `${END_POINT.GET_FESTIVAL_DETAIL}/${festivalId}`,
+  );
+  return response.data;
 };

--- a/apps/client/src/shared/apis/config/instance.ts
+++ b/apps/client/src/shared/apis/config/instance.ts
@@ -1,17 +1,15 @@
 import axios from 'axios';
 
+import { BASE_URL } from '@shared/constants/api';
+
 import { handleAPIError, handleCheckAndSetToken } from './interceptor';
 
 export const axiosInstance = axios.create({
-  baseURL: import.meta.env.VITE_BASE_URL,
+  baseURL: BASE_URL,
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
   },
-});
-
-export const axiosPublicInstance = axios.create({
-  baseURL: import.meta.env.VITE_BASE_URL,
 });
 
 export function get<T>(...args: Parameters<typeof axiosInstance.get>) {

--- a/apps/client/src/shared/apis/config/instance.ts
+++ b/apps/client/src/shared/apis/config/instance.ts
@@ -1,11 +1,11 @@
 import axios from 'axios';
 
-import { BASE_URL } from '@shared/constants/api';
+import { CONFIG } from '@shared/constants/api';
 
 import { handleAPIError, handleCheckAndSetToken } from './interceptor';
 
 export const axiosInstance = axios.create({
-  baseURL: BASE_URL,
+  baseURL: CONFIG.BASE_URL,
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',

--- a/apps/client/src/shared/apis/onboard/artist-related-keywords.ts
+++ b/apps/client/src/shared/apis/onboard/artist-related-keywords.ts
@@ -2,13 +2,13 @@ import { END_POINT } from '@shared/constants/api';
 import { BaseResponse } from '@shared/types/api';
 import { onboardResponse } from '@shared/types/onboard-response';
 
-import { axiosInstance } from '../config/instance';
+import { get } from '../config/instance';
 
 export const getArtistRelatedKeyword = async (
   keyword: string,
 ): Promise<onboardResponse> => {
-  const response = await axiosInstance.get<BaseResponse<onboardResponse>>(
+  const response = await get<BaseResponse<onboardResponse>>(
     END_POINT.GET_ARTIST_RELATED_KEYWORDS(keyword, 10),
   );
-  return response.data.data;
+  return response.data;
 };

--- a/apps/client/src/shared/apis/onboard/top-artist.ts
+++ b/apps/client/src/shared/apis/onboard/top-artist.ts
@@ -2,11 +2,12 @@ import { END_POINT } from '@shared/constants/api';
 import { BaseResponse } from '@shared/types/api';
 import { onboardResponse } from '@shared/types/onboard-response';
 
-import { axiosInstance } from '../config/instance';
+import { get } from '../config/instance';
 
 export const getTopArtist = async (): Promise<onboardResponse> => {
-  const response = await axiosInstance.get<BaseResponse<onboardResponse>>(
+  const response = await get<BaseResponse<onboardResponse>>(
     END_POINT.GET_TOP100_ARTIST,
   );
-  return response.data.data;
+
+  return response.data;
 };

--- a/apps/client/src/shared/apis/search/search.ts
+++ b/apps/client/src/shared/apis/search/search.ts
@@ -1,4 +1,4 @@
-import { axiosPublicInstance } from '@shared/apis/config/instance';
+import { get } from '@shared/apis/config/instance';
 import { END_POINT } from '@shared/constants/api';
 import { BaseResponse } from '@shared/types/api';
 import {
@@ -9,10 +9,10 @@ import {
 export const getArtistSearch = async (
   keyword: string,
 ): Promise<ArtistSearch> => {
-  const response = await axiosPublicInstance.get<BaseResponse<ArtistSearch>>(
+  const response = await get<BaseResponse<ArtistSearch>>(
     `${END_POINT.GET_ARTISTS_SEARCH}${encodeURIComponent(keyword)}`,
   );
-  return response.data.data;
+  return response.data;
 };
 
 export const getPerformancesSearch = async (
@@ -22,9 +22,6 @@ export const getPerformancesSearch = async (
   const baseUrl = `performances/association/${artistId}`;
   const url = cursor === 1 ? baseUrl : `${baseUrl}?cursor=${cursor}`;
 
-  const response =
-    await axiosPublicInstance.get<BaseResponse<GetPerformancesSearchResponse>>(
-      url,
-    );
-  return response.data.data;
+  const response = await get<BaseResponse<GetPerformancesSearchResponse>>(url);
+  return response.data;
 };

--- a/apps/client/src/shared/constants/api.ts
+++ b/apps/client/src/shared/constants/api.ts
@@ -1,4 +1,10 @@
-export const BASE_URL = import.meta.env.VITE_BASE_URL as string;
+export const CONFIG = {
+  BASE_URL: import.meta.env.VITE_BASE_URL as string,
+  KAKAO_REDIRECT_URI: import.meta.env.VITE_KAKAO_REDIRECT_URI as string,
+  KAKAO_URI: import.meta.env.VITE_KAKAO_URI as string,
+  AMPLITUDE_API_KEY: import.meta.env.VITE_AMPLITUDE_API_KEY as string,
+  SENTRY_DSN: import.meta.env.VITE_SENTRY_DSN as string,
+} as const;
 
 export const END_POINT = {
   GET_USER_PROFILE: '/user/info',

--- a/packages/design-system/src/components/performance-carousel/performance-carousel.css.ts
+++ b/packages/design-system/src/components/performance-carousel/performance-carousel.css.ts
@@ -87,3 +87,9 @@ export const badge = style({
   borderRadius: '13px',
   zIndex: themeVars.zIndex.poster.infoText,
 });
+
+export const carouselContainer = style({
+  display: 'flex',
+  justifyContent: 'center',
+  width: '100%',
+});

--- a/packages/design-system/src/components/performance-carousel/performance-carousel.tsx
+++ b/packages/design-system/src/components/performance-carousel/performance-carousel.tsx
@@ -81,10 +81,10 @@ const PerformanceCarousel = ({
   const settings = {
     ref: sliderRef,
     className: 'center',
-    dots: true,
+    dots: performData.length > 1,
     centerMode: true,
-    infinite: true,
-    variableWidth: true,
+    infinite: performData.length > 1,
+    variableWidth: performData.length > 1,
     centerPadding: '0px',
     slidesToShow: 1,
     slidesToScroll: 1,
@@ -114,7 +114,13 @@ const PerformanceCarousel = ({
 
   return (
     <CarouselContext.Provider value={contextValue}>
-      <div>{children}</div>
+      <div
+        className={
+          performData.length === 1 ? styles.carouselContainer : undefined
+        }
+      >
+        {children}
+      </div>
     </CarouselContext.Provider>
   );
 };


### PR DESCRIPTION
## 📌 Summary

> - #395

로그인 여부에 따른 API 호출 방식을 수정했어요.

## 📚 Tasks

- 환경변수 사용 CONFIG 객체로 통일
- 로그인 여부에 따른 API 호출 방식 수정

## 👀 To Reviewer

### 1. 환경변수 사용 CONFIG 객체로 통일
환경변수 관리를 일관된 방식으로 개선하기 위해, 개별적으로 사용하던 `import.meta.env` 접근을 `CONFIG` 객체로 통합했어요.
`as string` 처리로 타입 오류 방지하고, 자동완성 기능으로 휴먼에러를 감소시킬 수 있을 것이라 생각해요.


### 2. 로그인 여부에 따른 API 호출 방식 수정
기존에 언급되었던 `axiosInstance`와 `axiosPublicInstance`의 분리 사용 문제를 해결했어요.
로그인 여부에 따라 `Authorization` 헤더를 조건부로 추가하도록 `handleCheckAndSetToken`을 개선하여, 모든 요청을 하나의 `axiosInstance`로 처리할 수 있게 만들었어요.

기존에는 로그인하지 않은 사용자의 요청을 위해 `axiosPublicInstance`를 따로 사용했지만, 이 방식에는 다음과 같은 문제점이 있어요.

- **반환 형식 불일치**
`axiosInstance`는 `res.data`를 반환하는 반면(한 번더 추상화된 메서드 사용)
`axiosPublicInstance`는 `res.data.data`를 반환하여 응답 파싱 방식이 다름

- **중복 관리**
두 인스턴스를 병행해서 사용하면서 공통적인 설정이나 에러 처리 로직을 중복 구현해야함.

그래서...

인터셉터 레벨에서 `ACCESS_TOKEN_KEY` 존재 여부를 판단해 `Authorization` 헤더를 조건부로 추가했어요.

이를 통해 로그인 여부와 관계없이 `axiosInstance` 하나로 모든 API 요청이 가능합니다.
이제 API 요청 레벨에서는 로그인 여부를 신경 쓰지 않아도 되며, 기존 공통적인 인터셉터 로직으로 토큰 처리 및 에러 핸들링도 동일하게 작동해요.

> 하지만, `axiosPublicInstance`를 완전히 삭제하지 않은 이유는
`auth.ts`의 `postSocialLogin`내에서 `axiosInstance`를 사용하면 헤더에 `Authorization`를 포함하게 되어 로그인 오류가 발생합니다. 해당 부분 해결 가능하다면 의견 받겠습니다!

해당부분은 fetch로 수정하여 axiosPublicInstance는 완전히 제거했어요!

