### PR TITLE
Feat(client): 내 공연 페이지 MY 타임테이블 일부 목록 조회 api 연동

### DIFF
--- a/apps/client/src/pages/my-history/components/preview/preview-section.tsx
+++ b/apps/client/src/pages/my-history/components/preview/preview-section.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 
 import { Box, Button, FestivalCard } from '@confeti/design-system';
-import { Performance } from '@shared/types/user-response';
+import { MyTimeTable } from '@shared/types/my-history-response';
 
 import * as styles from './preview-section.css';
 
@@ -15,7 +15,7 @@ interface Props {
   title: string;
   showMore?: boolean;
   buttonLabel?: string;
-  performances?: Performance[];
+  previewData?: MyTimeTable[];
   emptyMessage: string;
   ctaText: string;
 }
@@ -25,11 +25,11 @@ const PreviewSection = ({
   title,
   showMore = true,
   buttonLabel = '전체보기',
-  performances,
+  previewData,
   emptyMessage,
   ctaText,
 }: Props) => {
-  const hasContent = performances && performances.length > 0;
+  const hasContent = previewData && previewData.length > 0;
   const navigate = useNavigate();
 
   const handleButtonClick = () => {
@@ -42,13 +42,12 @@ const PreviewSection = ({
     <Box title={title} showMore={showMore} showMoreText={buttonLabel}>
       {hasContent ? (
         <div className={styles.container}>
-          {performances.map((performance) => (
+          {previewData.map((previewData) => (
             <FestivalCard
-              key={performance.index}
-              typeId={performance.typeId}
-              type={performance.type}
-              title={performance.title}
-              imageSrc={performance.posterUrl}
+              key={previewData.typeId}
+              typeId={previewData.typeId}
+              title={previewData.title}
+              imageSrc={previewData.posterUrl}
             />
           ))}
         </div>

--- a/apps/client/src/pages/my-history/hooks/use-my-history.ts
+++ b/apps/client/src/pages/my-history/hooks/use-my-history.ts
@@ -1,0 +1,10 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { MY_HISTORY_TIME_TABLE_PREVIEW_QUERY_OPTION } from '@shared/apis/my-history/my-history-queries';
+
+export const useMyTimeTablePreview = () => {
+  const { data } = useSuspenseQuery(
+    MY_HISTORY_TIME_TABLE_PREVIEW_QUERY_OPTION.MY_TIME_TABLE_PREVIEW(),
+  );
+  return { data };
+};

--- a/apps/client/src/pages/my-history/page/record/my-record.tsx
+++ b/apps/client/src/pages/my-history/page/record/my-record.tsx
@@ -1,18 +1,17 @@
-import { useMyPerformancePreview } from '@pages/my/hooks/use-my-favorites';
 import { useUserProfile } from '@pages/my/hooks/use-user-info';
 import PreviewSection from '@pages/my-history/components/preview/preview-section';
 import RecordInfo from '@pages/my-history/components/record/record-info';
 import RecordIntroduce from '@pages/my-history/components/record/record-introduce';
+import { useMyTimeTablePreview } from '@pages/my-history/hooks/use-my-history';
 
 import { Footer, Spacing } from '@confeti/design-system';
 
 const MyRecord = () => {
   const { data: profileData } = useUserProfile();
 
-  // TODO: 실제 타임테이블 & 셋리스트 API 연결
-  const { data: performanceData } = useMyPerformancePreview();
+  const { data: timetablePreviewData } = useMyTimeTablePreview();
 
-  if (!profileData || !performanceData) {
+  if (!profileData || !timetablePreviewData) {
     return null;
   }
 
@@ -37,7 +36,7 @@ const MyRecord = () => {
       <PreviewSection
         previewType="TIME_TABLE"
         title="My 타임테이블"
-        performances={performanceData.performances.slice(0, 3)}
+        previewData={timetablePreviewData.timetables.slice(0, 3)}
         emptyMessage="아직 My 타임테이블이 없어요."
         ctaText="타임테이블 추가하기"
       />
@@ -46,7 +45,7 @@ const MyRecord = () => {
       <PreviewSection
         previewType="SET_LIST"
         title="My 셋리스트"
-        performances={performanceData.performances.slice(0, 1)}
+        // performances={timetablePreviewData.timetables}
         emptyMessage="아직 My 셋리스트가 없어요."
         ctaText="셋리스트 추가하기"
       />

--- a/apps/client/src/shared/apis/my-history/my-history-queries.ts
+++ b/apps/client/src/shared/apis/my-history/my-history-queries.ts
@@ -1,0 +1,21 @@
+import { queryOptions } from '@tanstack/react-query';
+
+import { getMyTimeTablePreview } from './my-history';
+
+export const MY_HISTORY_TIME_TABLE_PREVIEW_QUERY_KEY = {
+  ALL: ['time-table-preview'],
+  MY_TIME_TABLE_PREVIEW: () => [
+    ...MY_HISTORY_TIME_TABLE_PREVIEW_QUERY_KEY.ALL,
+    'time-table-preview',
+  ],
+} as const;
+
+export const MY_HISTORY_TIME_TABLE_PREVIEW_QUERY_OPTION = {
+  ALL: () =>
+    queryOptions({ queryKey: MY_HISTORY_TIME_TABLE_PREVIEW_QUERY_KEY.ALL }),
+  MY_TIME_TABLE_PREVIEW: () =>
+    queryOptions({
+      queryKey: MY_HISTORY_TIME_TABLE_PREVIEW_QUERY_KEY.MY_TIME_TABLE_PREVIEW(),
+      queryFn: getMyTimeTablePreview,
+    }),
+} as const;

--- a/apps/client/src/shared/apis/my-history/my-history.ts
+++ b/apps/client/src/shared/apis/my-history/my-history.ts
@@ -1,0 +1,12 @@
+import { END_POINT } from '@shared/constants/api';
+import { BaseResponse } from '@shared/types/api';
+import { MyHistoryResponse } from '@shared/types/my-history-response';
+
+import { get } from '../config/instance';
+
+export const getMyTimeTablePreview = async () => {
+  const response = await get<BaseResponse<MyHistoryResponse>>(
+    END_POINT.GET_MY_TIMETABLE,
+  );
+  return response.data;
+};

--- a/apps/client/src/shared/constants/api.ts
+++ b/apps/client/src/shared/constants/api.ts
@@ -7,6 +7,8 @@ export const CONFIG = {
 } as const;
 
 export const END_POINT = {
+  //내 공연
+  GET_MY_TIMETABLE: 'user/timetables/preview',
   GET_USER_PROFILE: '/user/info',
   GET_MY_UPCOMING_PERFORMANCE: '/user/favorites/performance',
   GET_MY_ARTISTS_PREVIEW: '/user/favorites/artists/preview',

--- a/apps/client/src/shared/types/my-history-response.ts
+++ b/apps/client/src/shared/types/my-history-response.ts
@@ -1,0 +1,7 @@
+import { Performances } from './performance-response';
+
+export type MyTimeTable = Pick<Performances, 'typeId' | 'posterUrl' | 'title'>;
+
+export interface MyHistoryResponse {
+  timetables: MyTimeTable[];
+}

--- a/packages/design-system/src/components/festival-card/festival-card.tsx
+++ b/packages/design-system/src/components/festival-card/festival-card.tsx
@@ -12,7 +12,7 @@ interface FestivalCardProps {
   isSelected?: boolean;
   selectable?: boolean;
   onSelectChange?: (title: string, isSelected: boolean) => void;
-  type: 'FESTIVAL' | 'CONCERT' | 'ARTIST';
+  type?: 'FESTIVAL' | 'CONCERT' | 'ARTIST';
   onClick?: () => void;
 }
 


### PR DESCRIPTION
## 📌 Summary

- #401 

## 📚 Tasks

- 일부 목록 조회 및 전체 목록 조회에 쓰일 타입, interface 정의 
- api 연동

## 👀 To Reviewer

일부 목록 조회 및 전체 목록 조회에 쓰일 타입을 Performances 에서 Pick 을 이용해서 정의했어요. 

이외에는 동일하게 api 연동 작업을 진행하였고, my-record 에서 festivalCard 컴포넌트가 사용되는데, 서버에서 type 값이 넘어오지 않기에 festivalCard 컴포넌트의 type props 를 `?` 속성을 부여했어요.

테스트는 타임테이블을 실제로 추가한 다음 진행하였습니다. 

빠른 리뷰 가능합니다.

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/0711d65f-01be-4cf4-8680-34ea7c05cfd7)

