### PR TITLE
Feat(client): 온보딩 페이지 auth/onboard post api 연동

### DIFF
--- a/apps/client/src/pages/onboarding/hooks/use-onboard.ts
+++ b/apps/client/src/pages/onboarding/hooks/use-onboard.ts
@@ -13,15 +13,6 @@ interface UseArtistRelatedKeywordProps {
   limit: number;
 }
 
-/**
- * 서버에서 인기 아티스트 목록을 가져오는 커스텀 훅
- *
- * 이 훅은 온보딩 화면에서 처음 진입할 때 사용됩니다.
- * 인기 아티스트 리스트를 서버에서 요청하여 반환합니다.
- *
- * @param limit - 가져올 아티스트의 최대 개수
- * @returns { data: onboard[] } - 인기 아티스트 목록 데이터
- */
 export const useGetTopArtist = (limit: number) => {
   const { data } = useSuspenseQuery({
     ...TOP_ARTIST_QUERY_OPTION.TOP_ARTIST(limit),
@@ -30,17 +21,6 @@ export const useGetTopArtist = (limit: number) => {
   return { data };
 };
 
-/**
- * 아티스트 연관 검색어를 가져오는 커스텀 훅
- *
- * 사용자가 입력한 검색 키워드에 맞춰 연관된 아티스트를 검색하여 가져옵니다.
- * 이 훅은 사용자가 입력한 검색 키워드에 따라 디바운싱 후 연관 검색어를 요청합니다.
- *
- * @param keyword - 사용자가 입력한 검색 키워드
- * @param enabled - 검색어가 있을 때만 쿼리를 실행하도록 설정하는 옵션
- * @param limit - 연관 검색어의 최대 개수
- * @returns { data: onboard[] | undefined } - 연관된 아티스트 데이터
- */
 export const useArtistRelatedKeyword = ({
   keyword,
   enabled,
@@ -54,15 +34,6 @@ export const useArtistRelatedKeyword = ({
   return data;
 };
 
-/**
- * 아티스트 연관 아티스트를 가져오는 커스텀 훅
- *
- * 이 훅은 기준이 되는 아티스트 ID에 맞춰 해당 아티스트와 연관된 다른 아티스트 데이터를 가져옵니다.
- * 성공적으로 데이터를 가져오면 `setArtists` 함수를 사용하여 연관 아티스트 목록을 업데이트합니다.
- *
- * @param setArtists - 연관 아티스트 목록을 업데이트하는 상태 변경 함수
- * @returns { mutate: Mutation } - 아티스트 연관 아티스트 데이터를 가져오는 Mutation 함수
- */
 export const useArtistRelatedArtist = () => {
   return useMutation<
     BaseResponse<onboardResponse>,
@@ -75,15 +46,6 @@ export const useArtistRelatedArtist = () => {
   });
 };
 
-/**
- * 온보딩 완료 후 인증된 아티스트 목록을 서버에 전송하는 커스텀 훅
- *
- * 이 훅은 사용자가 선택한 아티스트 목록을 서버에 전송하여 온보딩을 완료합니다.
- * 성공적으로 데이터를 전송하면 온보딩 상태가 갱신되며, 해당 데이터를 서버에 저장합니다.
- *
- * @param favoriteArtists - 사용자가 선택한 선호하는 아티스트 목록
- * @returns { mutate: Mutation } - 온보딩 완료 데이터를 서버에 전송하는 Mutation 함수
- */
 export const usePostAuthOnboarding = () => {
   return useMutation({
     mutationFn: (favoriteArtists: string[]) => {

--- a/apps/client/src/pages/onboarding/hooks/use-onboard.ts
+++ b/apps/client/src/pages/onboarding/hooks/use-onboard.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 
 import { getArtistRelatedArtist } from '@shared/apis/onboard/artist-related';
 import { ARTIST_RELATED_QUERY_OPTION } from '@shared/apis/onboard/artist-related-queries';
+import { postAuthOnboarding } from '@shared/apis/onboard/auth-onboard';
 import { TOP_ARTIST_QUERY_OPTION } from '@shared/apis/onboard/top-artist-queries';
 import { BaseResponse } from '@shared/types/api';
 import { onboardResponse } from '@shared/types/onboard-response';
@@ -70,6 +71,23 @@ export const useArtistRelatedArtist = () => {
   >({
     mutationFn: ({ artistId, limit }) => {
       return getArtistRelatedArtist(artistId, limit);
+    },
+  });
+};
+
+/**
+ * 온보딩 완료 후 인증된 아티스트 목록을 서버에 전송하는 커스텀 훅
+ *
+ * 이 훅은 사용자가 선택한 아티스트 목록을 서버에 전송하여 온보딩을 완료합니다.
+ * 성공적으로 데이터를 전송하면 온보딩 상태가 갱신되며, 해당 데이터를 서버에 저장합니다.
+ *
+ * @param favoriteArtists - 사용자가 선택한 선호하는 아티스트 목록
+ * @returns { mutate: Mutation } - 온보딩 완료 데이터를 서버에 전송하는 Mutation 함수
+ */
+export const usePostAuthOnboarding = () => {
+  return useMutation({
+    mutationFn: (favoriteArtists: string[]) => {
+      return postAuthOnboarding(favoriteArtists);
     },
   });
 };

--- a/apps/client/src/pages/onboarding/page/onboarding.tsx
+++ b/apps/client/src/pages/onboarding/page/onboarding.tsx
@@ -55,12 +55,13 @@ const Onboarding = () => {
       <Step name="1">
         <ArtistSelect artists={artists} onArtistSelect={handleArtistSelect}>
           <Button
-            text={'시작하기'}
+            text={'다음'}
             variant={'add'}
             onClick={() => {
               mutateAuthOnboard(selectedArtistIds);
               setStep(1);
             }}
+            disabled={selectedArtistIds.length < 1}
           />
         </ArtistSelect>
       </Step>

--- a/apps/client/src/pages/onboarding/page/onboarding.tsx
+++ b/apps/client/src/pages/onboarding/page/onboarding.tsx
@@ -2,34 +2,66 @@ import { useState } from 'react';
 
 import { Button } from '@confeti/design-system';
 import { routePath } from '@shared/constants/path';
+import { onboard } from '@shared/types/onboard-response';
 import { useFunnel } from '@shared/utils/use-funnel';
 
 import ArtistSelect from '../components/artist-select';
 import OnBoardingComplete from '../components/onboarding-complete';
 import { ONBOARD_LIMIT } from '../constants/limit';
-import { useArtistRelatedArtist, useGetTopArtist } from '../hooks/use-onboard';
+import {
+  useArtistRelatedArtist,
+  useGetTopArtist,
+  usePostAuthOnboarding,
+} from '../hooks/use-onboard';
 
 const Onboarding = () => {
   const TOTAL_STEPS = 2;
   const { Funnel, Step, setStep } = useFunnel(TOTAL_STEPS, routePath.ROOT);
   const { data: topArtistData } = useGetTopArtist(ONBOARD_LIMIT.TOP_ARTIST);
   const [artists, setArtists] = useState(topArtistData?.artists || []);
+  const [selectedArtistIds, setSelectedArtistIds] = useState<string[]>([]);
   const { mutateAsync } = useArtistRelatedArtist();
+  const { mutate: mutateAuthOnboard } = usePostAuthOnboarding();
 
   const handleArtistSelect = async (artistId: string) => {
+    const updatedArtists = await fetchRelatedArtists(
+      artistId,
+      ONBOARD_LIMIT.RELATED_ARTIST,
+    );
+    updateRenderArtists(updatedArtists);
+    updateSelectedArtistIds(artistId);
+  };
+
+  const fetchRelatedArtists = async (artistId: string, limit: number) => {
     const relatedArtist = await mutateAsync({
       artistId,
-      limit: ONBOARD_LIMIT.RELATED_ARTIST,
+      limit,
     });
-    const updatedArtists = relatedArtist?.data?.artists || [];
+    return relatedArtist?.data?.artists || [];
+  };
+
+  const updateRenderArtists = (updatedArtists: onboard[]) => {
     setArtists(updatedArtists);
+  };
+
+  const updateSelectedArtistIds = (artistId: string) => {
+    setSelectedArtistIds((prev) =>
+      prev.includes(artistId) ? prev : [...prev, artistId],
+    );
   };
 
   return (
     <Funnel>
       <Step name="1">
         <ArtistSelect artists={artists} onArtistSelect={handleArtistSelect}>
-          <Button text={'다음'} variant={'add'} onClick={() => setStep(1)} />
+          <Button
+            text={'시작하기'}
+            variant={'add'}
+            onClick={() => {
+              mutateAuthOnboard(selectedArtistIds);
+              setStep(1);
+            }}
+          />
         </ArtistSelect>
       </Step>
       <Step name="2">

--- a/apps/client/src/shared/apis/onboard/auth-onboard.ts
+++ b/apps/client/src/shared/apis/onboard/auth-onboard.ts
@@ -1,0 +1,13 @@
+import { END_POINT } from '@shared/constants/api';
+import { BaseResponse } from '@shared/types/api';
+
+import { post } from '../config/instance';
+
+export const postAuthOnboarding = async (
+  favoriteArtists: string[],
+): Promise<void> => {
+  const requestBody = {
+    favoriteArtists: favoriteArtists.map((id) => ({ artistId: id })),
+  };
+  await post<BaseResponse<null>>(END_POINT.POST_AUTH_ONBOARD, requestBody);
+};

--- a/apps/client/src/shared/constants/api.ts
+++ b/apps/client/src/shared/constants/api.ts
@@ -56,6 +56,7 @@ export const END_POINT = {
     `user/onboard/artists/search?term=${encodeURIComponent(keyword)}&limit=${limit}`,
   GET_ARTIST_RELATED_ARTIST: (artistId: string, limit: number) =>
     `user/onboard/artists/${artistId}/related?limit=${limit}`,
+  POST_AUTH_ONBOARD: `auth/onboard`,
 } as const;
 
 export const HTTP_STATUS_CODE = {


### PR DESCRIPTION
## 📌 Summary

- #405 

## 📚 Tasks

- 버튼 text '다음'으로 변경
- 유저가 하나 이상의 선호 아티스트를 선택해야 하는 요구사항 반영했습니다.
- post api 연동하였습니다.

## 👀 To Reviewer

onboard 페이지 컴포넌트에 상태 업데이트 및 리패칭 하는 함수들이 존재합니다.  페이지와 분리하기 애매하다고 생각하여 최대한 책임을 분리한 후에 onboard 컴포넌트 내부에 두었는데 좋은 아이디어가 있으면 말씀해주세요.

그리고 기획이 제시해준 요구사항에는 유저가 한명 이상의 아티스트를 선택해야 버튼이 활성화 된다고 명시 되어 있어서 반영하였으나, 서버에서 설계한 api 에서는 `2`개 이하일 때 400 에러를 반환하고 있기에 슬랙을 통해 api 수정 요청 드렸습니다.

그리고 use-onboard 에 있는 tsdoc 주석을 제거하였는데 로직이 비교적 단순하고, 네이밍도 직관적으로 설계되어 있다고 판단하여 오히려 주석이 가독성을 해치는 느낌이라 제거하였습니다


<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요. 필요시 .gif 형식으로 첨부해주세요.
-->
