### PR TITLE
Feat(client): 요청 공연 타입 분석 및 예정된 공연 목록 조회 API 연동

### DIFF
--- a/apps/client/src/pages/search/components/search-result/performance/performance-info.tsx
+++ b/apps/client/src/pages/search/components/search-result/performance/performance-info.tsx
@@ -9,7 +9,6 @@ import { formatDate } from '@shared/utils/format-date';
 import * as styles from './performance-info.css';
 
 const PerformanceInfo = ({
-  typeId,
   posterUrl,
   title,
   startAt,

--- a/apps/client/src/pages/search/components/search-result/performance/performance-info.tsx
+++ b/apps/client/src/pages/search/components/search-result/performance/performance-info.tsx
@@ -16,6 +16,7 @@ const PerformanceInfo = ({
   area,
   isFavorite,
   type,
+  typeId,
 }: Performance) => {
   const { mutate } = useLikeMutation();
   const handleLike = (action: 'LIKE' | 'UNLIKE') => {

--- a/apps/client/src/pages/search/components/search-result/performance/performance-info.tsx
+++ b/apps/client/src/pages/search/components/search-result/performance/performance-info.tsx
@@ -9,6 +9,7 @@ import { formatDate } from '@shared/utils/format-date';
 import * as styles from './performance-info.css';
 
 const PerformanceInfo = ({
+  typeId,
   posterUrl,
   title,
   startAt,
@@ -16,7 +17,6 @@ const PerformanceInfo = ({
   area,
   isFavorite,
   type,
-  typeId,
 }: Performance) => {
   const { mutate } = useLikeMutation();
   const handleLike = (action: 'LIKE' | 'UNLIKE') => {

--- a/apps/client/src/pages/search/components/search-result/performance/performance-section.tsx
+++ b/apps/client/src/pages/search/components/search-result/performance/performance-section.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@confeti/design-system';
-import { Performance } from '@shared/types/search-reponse';
+import { IntendedPerformance } from '@shared/types/search-reponse';
 
 import PerformanceInfo from './performance-info';
 
@@ -7,7 +7,7 @@ import * as styles from './performance-section.css';
 
 interface Props {
   performanceCount: number;
-  performances: Performance[];
+  performances: IntendedPerformance[];
 }
 
 const PerformanceSection = ({ performanceCount, performances }: Props) => {

--- a/apps/client/src/pages/search/hooks/use-search-data.ts
+++ b/apps/client/src/pages/search/hooks/use-search-data.ts
@@ -6,15 +6,16 @@ import {
 
 import { SEARCH_ARTIST_QUERY_OPTION } from '@shared/apis/search/search-queries';
 import { SEARCH_ARTIST_RELATED_QUERY_OPTION } from '@shared/apis/search/search-queries';
+import { IntendedPerformanceRequest } from '@shared/types/search-reponse';
 
 import { SEARCH_PERFORMANCE_QUERY_OPTION } from './../../../shared/apis/search/search-queries';
 
-interface UseArtistProps {
+interface KeywordProps {
   keyword: string;
   enabled: boolean;
 }
 
-export const useSearchArtist = ({ keyword, enabled }: UseArtistProps) => {
+export const useSearchArtist = ({ keyword, enabled }: KeywordProps) => {
   const { data, isLoading } = useQuery({
     ...SEARCH_ARTIST_QUERY_OPTION.SEARCH_ARTIST(keyword, enabled),
   });
@@ -40,7 +41,7 @@ export const useArtistRelatedData = (artistId: string | null) => {
   };
 };
 
-export const useRelatedSearch = ({ keyword, enabled }: UseArtistProps) => {
+export const useRelatedSearch = ({ keyword, enabled }: KeywordProps) => {
   return useQueries({
     queries: [
       SEARCH_ARTIST_QUERY_OPTION.SEARCH_RELATED_KEYWORD(keyword, enabled),
@@ -57,4 +58,37 @@ export const useRelatedSearch = ({ keyword, enabled }: UseArtistProps) => {
       isLoading: results.some((r) => r.isLoading),
     }),
   });
+};
+
+export const usePerformanceTypeAnalysis = ({
+  keyword,
+  enabled,
+}: KeywordProps) => {
+  const { data, isLoading } = useQuery({
+    ...SEARCH_PERFORMANCE_QUERY_OPTION.SEARCH_PERFORMANCE_TYPE_ANALYSIS(
+      keyword,
+      enabled,
+    ),
+  });
+
+  return { data, isLoading };
+};
+
+interface UseIntendedPerformanceProps {
+  request: IntendedPerformanceRequest;
+  enabled: boolean;
+}
+
+export const useIntendedPerformance = ({
+  request,
+  enabled,
+}: UseIntendedPerformanceProps) => {
+  const { data, isLoading } = useQuery({
+    ...SEARCH_PERFORMANCE_QUERY_OPTION.SEARCH_INTENDED_PERFORMANCE(
+      request,
+      enabled,
+    ),
+  });
+
+  return { data, isLoading };
 };

--- a/apps/client/src/pages/search/hooks/use-search-data.ts
+++ b/apps/client/src/pages/search/hooks/use-search-data.ts
@@ -1,11 +1,6 @@
-import {
-  useQueries,
-  useQuery,
-  useSuspenseQueries,
-} from '@tanstack/react-query';
+import { useQueries, useQuery } from '@tanstack/react-query';
 
 import { SEARCH_ARTIST_QUERY_OPTION } from '@shared/apis/search/search-queries';
-import { SEARCH_ARTIST_RELATED_QUERY_OPTION } from '@shared/apis/search/search-queries';
 import { IntendedPerformanceRequest } from '@shared/types/search-reponse';
 
 import { SEARCH_PERFORMANCE_QUERY_OPTION } from './../../../shared/apis/search/search-queries';
@@ -21,24 +16,6 @@ export const useSearchArtist = ({ keyword, enabled }: KeywordProps) => {
   });
 
   return { data, isLoading };
-};
-
-export const useArtistRelatedData = (artistId: string | null) => {
-  const results = useSuspenseQueries({
-    queries: [
-      {
-        ...SEARCH_ARTIST_RELATED_QUERY_OPTION.SEARCH_RELATED_PERFORMANCES(
-          artistId,
-        ),
-      },
-    ],
-  });
-
-  const [performancesQuery] = results;
-
-  return {
-    performancesData: performancesQuery?.data,
-  };
 };
 
 export const useRelatedSearch = ({ keyword, enabled }: KeywordProps) => {

--- a/apps/client/src/pages/search/hooks/use-search-data.ts
+++ b/apps/client/src/pages/search/hooks/use-search-data.ts
@@ -1,4 +1,4 @@
-import { useQueries, useQuery } from '@tanstack/react-query';
+import { useQueries, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 
 import { SEARCH_ARTIST_QUERY_OPTION } from '@shared/apis/search/search-queries';
 import { IntendedPerformanceRequest } from '@shared/types/search-reponse';
@@ -53,19 +53,14 @@ export const usePerformanceTypeAnalysis = ({
 
 interface UseIntendedPerformanceProps {
   request: IntendedPerformanceRequest;
-  enabled: boolean;
 }
 
 export const useIntendedPerformance = ({
   request,
-  enabled,
 }: UseIntendedPerformanceProps) => {
-  const { data, isLoading } = useQuery({
-    ...SEARCH_PERFORMANCE_QUERY_OPTION.SEARCH_INTENDED_PERFORMANCE(
-      request,
-      enabled,
-    ),
+  const { data } = useSuspenseQuery({
+    ...SEARCH_PERFORMANCE_QUERY_OPTION.SEARCH_INTENDED_PERFORMANCE(request),
   });
 
-  return { data, isLoading };
+  return { data };
 };

--- a/apps/client/src/pages/search/page/search-page.tsx
+++ b/apps/client/src/pages/search/page/search-page.tsx
@@ -9,7 +9,6 @@ import PopularSearchSection from '../components/search-home/popular-search-secti
 import RecentFestivalSection from '../components/search-home/recent-festivals-section';
 import RecentSearchSection from '../components/search-home/recent-search-section';
 import {
-  useIntendedPerformance,
   usePerformanceTypeAnalysis,
   useRelatedSearch,
   useSearchArtist,
@@ -47,16 +46,6 @@ const SearchPage = () => {
   const { data: performanceTypeAnalysisData } = usePerformanceTypeAnalysis({
     keyword: searchKeyword,
     enabled: !!searchKeyword.trim() && isPerformanceAnalysisTriggered,
-  });
-
-  const { data: intendedPerformanceData } = useIntendedPerformance({
-    request: {
-      pid: Number(relatedPerformances?.performances[0]?.id) || null,
-      aid: artistData?.artist.artistId || null,
-      ptitle: performanceTypeAnalysisData?.processedTerm || null,
-      ptype: performanceTypeAnalysisData?.performanceType || null,
-    },
-    enabled: !!artistData || !!performanceTypeAnalysisData,
   });
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -109,7 +98,8 @@ const SearchPage = () => {
         return (
           <SearchResult
             artistData={artistData?.artist ?? null}
-            intendedPerformanceData={intendedPerformanceData ?? null}
+            relatedPerformances={relatedPerformances ?? null}
+            performanceTypeAnalysisData={performanceTypeAnalysisData ?? null}
           />
         );
 

--- a/apps/client/src/pages/search/page/search-result-page.tsx
+++ b/apps/client/src/pages/search/page/search-result-page.tsx
@@ -1,5 +1,8 @@
 import { Footer, Spacing } from '@confeti/design-system';
-import { ArtistSearch } from '@shared/types/search-reponse';
+import {
+  ArtistSearch,
+  IntendedPerformanceResponse,
+} from '@shared/types/search-reponse';
 
 import ArtistNotFound from '../components/search-result/artist/artist-not-found';
 import ArtistSection from '../components/search-result/artist/artist-section';
@@ -11,8 +14,9 @@ import * as styles from './search-result-page.css';
 
 interface Props {
   artistData: ArtistSearch | null;
+  intendedPerformanceData: IntendedPerformanceResponse | null;
 }
-const SearchResult = ({ artistData }: Props) => {
+const SearchResult = ({ artistData, intendedPerformanceData }: Props) => {
   const { performancesData } = useArtistRelatedData(
     artistData?.artistId || null,
   );
@@ -26,8 +30,8 @@ const SearchResult = ({ artistData }: Props) => {
             <ArtistSection artist={artistData} />
             <Spacing />
             <PerformanceSection
-              performanceCount={performancesData?.performances.length ?? 0}
-              performances={performancesData?.performances ?? []}
+              performanceCount={intendedPerformanceData?.performanceCount ?? 0}
+              performances={intendedPerformanceData?.performances ?? []}
             />
           </>
         ) : (

--- a/apps/client/src/pages/search/page/search-result-page.tsx
+++ b/apps/client/src/pages/search/page/search-result-page.tsx
@@ -8,7 +8,6 @@ import ArtistNotFound from '../components/search-result/artist/artist-not-found'
 import ArtistSection from '../components/search-result/artist/artist-section';
 import NoticeSection from '../components/search-result/notice-section';
 import PerformanceSection from '../components/search-result/performance/performance-section';
-import { useArtistRelatedData } from '../hooks/use-search-data';
 
 import * as styles from './search-result-page.css';
 
@@ -17,10 +16,6 @@ interface Props {
   intendedPerformanceData: IntendedPerformanceResponse | null;
 }
 const SearchResult = ({ artistData, intendedPerformanceData }: Props) => {
-  const { performancesData } = useArtistRelatedData(
-    artistData?.artistId || null,
-  );
-
   return (
     <>
       <main className={styles.resultSection}>

--- a/apps/client/src/pages/search/page/search-result-page.tsx
+++ b/apps/client/src/pages/search/page/search-result-page.tsx
@@ -1,21 +1,38 @@
 import { Footer, Spacing } from '@confeti/design-system';
 import {
   ArtistSearch,
-  IntendedPerformanceResponse,
+  PerformanceTypeAnalysis,
+  RelatedPerformanceResponse,
 } from '@shared/types/search-reponse';
 
 import ArtistNotFound from '../components/search-result/artist/artist-not-found';
 import ArtistSection from '../components/search-result/artist/artist-section';
 import NoticeSection from '../components/search-result/notice-section';
 import PerformanceSection from '../components/search-result/performance/performance-section';
+import { useIntendedPerformance } from '../hooks/use-search-data';
 
 import * as styles from './search-result-page.css';
 
 interface Props {
   artistData: ArtistSearch | null;
-  intendedPerformanceData: IntendedPerformanceResponse | null;
+  relatedPerformances: RelatedPerformanceResponse | null;
+  performanceTypeAnalysisData: PerformanceTypeAnalysis | null;
 }
-const SearchResult = ({ artistData, intendedPerformanceData }: Props) => {
+
+const SearchResult = ({
+  artistData,
+  relatedPerformances,
+  performanceTypeAnalysisData,
+}: Props) => {
+  const { data: intendedPerformanceData } = useIntendedPerformance({
+    request: {
+      pid: Number(relatedPerformances?.performances?.[0]?.id) || null,
+      aid: artistData?.artistId || null,
+      ptitle: performanceTypeAnalysisData?.processedTerm || null,
+      ptype: performanceTypeAnalysisData?.performanceType || null,
+    },
+  });
+
   return (
     <>
       <main className={styles.resultSection}>

--- a/apps/client/src/shared/apis/search/search-queries.ts
+++ b/apps/client/src/shared/apis/search/search-queries.ts
@@ -1,10 +1,14 @@
 import { queryOptions } from '@tanstack/react-query';
 
+import { IntendedPerformanceRequest } from '@shared/types/search-reponse';
+
 import {
   getArtistRelatedKeyword,
   getArtistRelatedPerformances,
   getArtistSearch,
+  getIntendedPerformance,
   getPerformanceRelatedKeyword,
+  getPerformanceTypeAnalysis,
 } from './search';
 
 export const SEARCH_ARTIST_QUERY_KEY = {
@@ -37,6 +41,19 @@ export const SEARCH_PERFORMANCE_QUERY_KEY = {
     'search',
     keyword,
   ],
+  SEARCH_PERFORMANCE_TYPE_ANALYSIS: (keyword: string) => [
+    ...SEARCH_PERFORMANCE_QUERY_KEY.ALL,
+    'type-analysis',
+    keyword,
+  ],
+  SEARCH_INTENDED_PERFORMANCE: (request: IntendedPerformanceRequest) => [
+    ...SEARCH_PERFORMANCE_QUERY_KEY.ALL,
+    'intended',
+    request.pid,
+    request.aid,
+    request.ptitle,
+    request.ptype,
+  ],
 } as const;
 
 export const SEARCH_PERFORMANCE_QUERY_OPTION = {
@@ -44,6 +61,20 @@ export const SEARCH_PERFORMANCE_QUERY_OPTION = {
   SEARCH_RELATED_PERFORMANCES: (keyword: string, enabled: boolean) => ({
     queryKey: SEARCH_PERFORMANCE_QUERY_KEY.SEARCH_PERFORMANCES(keyword),
     queryFn: () => getPerformanceRelatedKeyword(keyword),
+    enabled,
+  }),
+  SEARCH_PERFORMANCE_TYPE_ANALYSIS: (keyword: string, enabled: boolean) => ({
+    queryKey:
+      SEARCH_PERFORMANCE_QUERY_KEY.SEARCH_PERFORMANCE_TYPE_ANALYSIS(keyword),
+    queryFn: () => getPerformanceTypeAnalysis(keyword),
+    enabled,
+  }),
+  SEARCH_INTENDED_PERFORMANCE: (
+    request: IntendedPerformanceRequest,
+    enabled: boolean,
+  ) => ({
+    queryKey: SEARCH_PERFORMANCE_QUERY_KEY.SEARCH_INTENDED_PERFORMANCE(request),
+    queryFn: () => getIntendedPerformance(request),
     enabled,
   }),
 };

--- a/apps/client/src/shared/apis/search/search-queries.ts
+++ b/apps/client/src/shared/apis/search/search-queries.ts
@@ -4,7 +4,6 @@ import { IntendedPerformanceRequest } from '@shared/types/search-reponse';
 
 import {
   getArtistRelatedKeyword,
-  getArtistRelatedPerformances,
   getArtistSearch,
   getIntendedPerformance,
   getPerformanceRelatedKeyword,

--- a/apps/client/src/shared/apis/search/search-queries.ts
+++ b/apps/client/src/shared/apis/search/search-queries.ts
@@ -78,23 +78,3 @@ export const SEARCH_PERFORMANCE_QUERY_OPTION = {
     enabled,
   }),
 };
-
-// TODO: 추후 삭제 예정
-export const SEARCH_ARTIST_RELATED_QUERY_KEY = {
-  ALL: ['performances'],
-  SEARCH_RELATED_PERFORMANCES: (artistId: string | null) => [
-    ...SEARCH_ARTIST_RELATED_QUERY_KEY.ALL,
-    'search',
-    artistId,
-  ],
-} as const;
-
-// TODO: 추후 삭제 예정
-export const SEARCH_ARTIST_RELATED_QUERY_OPTION = {
-  ALL: () => queryOptions({ queryKey: SEARCH_ARTIST_RELATED_QUERY_KEY.ALL }),
-  SEARCH_RELATED_PERFORMANCES: (artistId: string | null) => ({
-    queryKey:
-      SEARCH_ARTIST_RELATED_QUERY_KEY.SEARCH_RELATED_PERFORMANCES(artistId),
-    queryFn: () => getArtistRelatedPerformances(artistId),
-  }),
-};

--- a/apps/client/src/shared/apis/search/search-queries.ts
+++ b/apps/client/src/shared/apis/search/search-queries.ts
@@ -68,12 +68,8 @@ export const SEARCH_PERFORMANCE_QUERY_OPTION = {
     queryFn: () => getPerformanceTypeAnalysis(keyword),
     enabled,
   }),
-  SEARCH_INTENDED_PERFORMANCE: (
-    request: IntendedPerformanceRequest,
-    enabled: boolean,
-  ) => ({
+  SEARCH_INTENDED_PERFORMANCE: (request: IntendedPerformanceRequest) => ({
     queryKey: SEARCH_PERFORMANCE_QUERY_KEY.SEARCH_INTENDED_PERFORMANCE(request),
     queryFn: () => getIntendedPerformance(request),
-    enabled,
   }),
 };

--- a/apps/client/src/shared/apis/search/search.ts
+++ b/apps/client/src/shared/apis/search/search.ts
@@ -5,7 +5,6 @@ import {
   ArtistSearchResponse,
   IntendedPerformanceRequest,
   IntendedPerformanceResponse,
-  PerformancesSearchResponse,
   PerformanceTypeAnalysis,
   RelatedArtistResponse,
   RelatedPerformanceResponse,

--- a/apps/client/src/shared/apis/search/search.ts
+++ b/apps/client/src/shared/apis/search/search.ts
@@ -38,15 +38,6 @@ export const getPerformanceRelatedKeyword = async (
   return response.data;
 };
 
-export const getArtistRelatedPerformances = async (
-  artistId: string | null,
-): Promise<PerformancesSearchResponse> => {
-  const response = await get<BaseResponse<PerformancesSearchResponse>>(
-    `${END_POINT.GET_PERFORMANCES_SEARCH(artistId)}`,
-  );
-  return response.data;
-};
-
 export const getPerformanceTypeAnalysis = async (
   keyword: string,
 ): Promise<PerformanceTypeAnalysis> => {

--- a/apps/client/src/shared/apis/search/search.ts
+++ b/apps/client/src/shared/apis/search/search.ts
@@ -3,7 +3,10 @@ import { END_POINT } from '@shared/constants/api';
 import { BaseResponse } from '@shared/types/api';
 import {
   ArtistSearchResponse,
+  IntendedPerformanceRequest,
+  IntendedPerformanceResponse,
   PerformancesSearchResponse,
+  PerformanceTypeAnalysis,
   RelatedArtistResponse,
   RelatedPerformanceResponse,
 } from '@shared/types/search-reponse';
@@ -41,5 +44,32 @@ export const getArtistRelatedPerformances = async (
   const response = await get<BaseResponse<PerformancesSearchResponse>>(
     `${END_POINT.GET_PERFORMANCES_SEARCH(artistId)}`,
   );
+  return response.data;
+};
+
+export const getPerformanceTypeAnalysis = async (
+  keyword: string,
+): Promise<PerformanceTypeAnalysis> => {
+  const response = await get<BaseResponse<PerformanceTypeAnalysis>>(
+    `${END_POINT.GET_PERFORMANCE_TYPE_ANALYSIS(keyword)}`,
+  );
+  return response.data;
+};
+
+export const getIntendedPerformance = async (
+  request: IntendedPerformanceRequest,
+): Promise<IntendedPerformanceResponse> => {
+  const { pid, aid, ptitle, ptype } = request;
+
+  const query = new URLSearchParams();
+
+  if (pid !== null) query.append('pid', String(pid));
+  if (aid !== null) query.append('aid', aid);
+  if (ptitle !== null) query.append('ptitle', ptitle);
+  if (ptype !== null) query.append('ptype', ptype);
+
+  const url = `performances/search?${query.toString()}`;
+
+  const response = await get<BaseResponse<IntendedPerformanceResponse>>(url);
   return response.data;
 };

--- a/apps/client/src/shared/constants/api.ts
+++ b/apps/client/src/shared/constants/api.ts
@@ -52,8 +52,6 @@ export const END_POINT = {
     `artists/search/ac?term=${encodeURIComponent(keyword)}&limit=${limit}`,
   GET_PERFORMANCES_SEARCH_RELATED_KEYWORD: (keyword: string, limit: number) =>
     `performances/search/ac?term=${encodeURIComponent(keyword)}&limit=${limit}`,
-  GET_PERFORMANCES_SEARCH: (artistId: string | null) =>
-    `performances/association/${artistId}`,
   GET_PERFORMANCE_TYPE_ANALYSIS: (keyword: string) =>
     `performances/search/type-analysis?term=${encodeURIComponent(keyword)}`,
 

--- a/apps/client/src/shared/constants/api.ts
+++ b/apps/client/src/shared/constants/api.ts
@@ -29,6 +29,7 @@ export const END_POINT = {
     `user/favorites/concerts/${concertId}`,
   GET_FESTIVAL_DETAIL: '/performances/festivals',
   GET_CONCERT_DETAIL: '/performances/concerts',
+
   // 홈 페이지
   GET_TICKETING: '/performances/reservation',
   GET_LATEST_PERFORMANCES: 'performances/info',
@@ -40,6 +41,10 @@ export const END_POINT = {
   GET_FESTIVAL_TIMETABLE: (festivalDateId: number) =>
     `user/timetables/festivals/${festivalDateId}`,
   POST_FESTIVAL_TIMETABLE: `user/timetables/festivals`,
+  DEL_FESTIVAL_TIMETABLES: (festivalId: number) =>
+    `user/timetables/festivals/${festivalId}`,
+  GET_FESTIVAL_TO_ADD: (cursor?: number) =>
+    `/user/timetables/festivals/add${cursor ? `?cursor=${cursor}` : ''}`,
 
   //검색
   GET_ARTISTS_SEARCH: `artists/search?term=`,
@@ -49,16 +54,15 @@ export const END_POINT = {
     `performances/search/ac?term=${encodeURIComponent(keyword)}&limit=${limit}`,
   GET_PERFORMANCES_SEARCH: (artistId: string | null) =>
     `performances/association/${artistId}`,
-  GET_FESTIVAL_TO_ADD: (cursor?: number) =>
-    `/user/timetables/festivals/add${cursor ? `?cursor=${cursor}` : ''}`,
-  DEL_FESTIVAL_TIMETABLES: (festivalId: number) =>
-    `user/timetables/festivals/${festivalId}`,
+  GET_PERFORMANCE_TYPE_ANALYSIS: (keyword: string) =>
+    `performances/search/type-analysis?term=${encodeURIComponent(keyword)}`,
 
   //로그인,로그아웃,토큰재발급
   POST_SOCIAL_LOGIN: 'auth/login',
   POST_LOGOUT: 'auth/logout',
   POST_REISSUE_TOKEN: 'auth/reissue',
   DELETE_ACCOUNT: 'auth/withdraw',
+
   //온보딩
   GET_TOP100_ARTIST: (limit: number) => `user/onboard/artists?limit=${limit}`,
   GET_ARTIST_RELATED_KEYWORDS: (keyword: string, limit: number) =>

--- a/apps/client/src/shared/types/search-reponse.ts
+++ b/apps/client/src/shared/types/search-reponse.ts
@@ -46,3 +46,30 @@ export interface RelatedPerformance {
 export interface RelatedPerformanceResponse {
   performances: RelatedPerformance[];
 }
+
+export interface PerformanceTypeAnalysis {
+  processedTerm: string;
+  performanceType: 'CONCERT' | 'FESTIVAL' | 'PERFORMANCE';
+}
+
+export interface IntendedPerformance {
+  performanceId: number;
+  title: string;
+  posterUrl: string;
+  area: string;
+  startAt: string;
+  endAt: string;
+  isFavorite: boolean;
+}
+
+export interface IntendedPerformanceResponse {
+  performanceCount: number;
+  performances: IntendedPerformance[];
+}
+
+export interface IntendedPerformanceRequest {
+  pid: number | null;
+  aid: string | null;
+  ptitle: string | null;
+  ptype: 'FESTIVAL' | 'CONCERT' | 'PERFORMANCE' | null;
+}

--- a/apps/client/src/shared/types/search-reponse.ts
+++ b/apps/client/src/shared/types/search-reponse.ts
@@ -54,6 +54,8 @@ export interface PerformanceTypeAnalysis {
 
 export interface IntendedPerformance {
   performanceId: number;
+  typeId: number;
+  type: 'FESTIVAL' | 'CONCERT' | 'ARTIST';
   title: string;
   posterUrl: string;
   area: string;


### PR DESCRIPTION
## 📌 Summary

> - #418 

요청 공연 타입 분석 및 예정된 공연 목록 조회 API를 연동했어요.

## 📚 Tasks

- 요청 공연 타입 분석 API 연동
- 예정된 공연 목록 조회 API를 연동


## 👀 To Reviewer

요청 공연 타입 분석 API를 연동하여, 사용자가 검색했을때 키워드랑 공연타입을 분석해요.
그리고 해당 결과를 통해 예정된 공연 목록 조회 API를 호출합니다.

예정된 공연 목록 조회 API의 케이스가 3가지가 있는데, 현재 첫번째 케이스 (아티스트 검색) 부분만 구현된 상태입니다.
그래서 공연 단독 조회는 현재 안됩니다.

공연 단독 조회를 하려면 기존 로직에서 수정해야할게 백만가지가 넘어서 막막합니다.