### PR TITLE
Feat(client): 셋리스트 공연추가 페이지 제작 및 조회 API 연동

### DIFF
--- a/apps/client/src/pages/my-history/components/add-setlist/setlist-performance.css.ts
+++ b/apps/client/src/pages/my-history/components/add-setlist/setlist-performance.css.ts
@@ -5,9 +5,8 @@ import { themeVars } from '@confeti/design-system/styles';
 export const container = style({
   ...themeVars.display.flexColumn,
   width: '100%',
-  height: 'calc(100dvh - 1rem)',
+  height: 'calc(100dvh - 5rem)',
   padding: '2rem 2rem 0 2rem',
-  overflowY: 'auto',
 });
 
 export const title = style({
@@ -23,22 +22,15 @@ export const performanceContainer = style({
   gridTemplateColumns: 'repeat(3, 1fr)',
   gridColumnGap: '1.8rem',
   gridRowGap: '3rem',
-  paddingBottom: '10rem',
 });
 
 export const buttonSection = style({
   position: 'fixed',
-  bottom: '0',
-  left: '0',
-  right: '0',
-  height: '9rem',
-  padding: '0 2rem',
-
+  padding: '2rem',
+  bottom: 0,
+  left: '50%',
+  width: 'min(100%, var(--max-width))',
+  transform: 'translateX(-50%)',
   background:
     'linear-gradient(180deg, rgba(255, 255, 255, 0.00) 0%, #FFF 100%)',
-
-  zIndex: 100,
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
 });

--- a/apps/client/src/pages/my-history/components/add-setlist/setlist-performance.css.ts
+++ b/apps/client/src/pages/my-history/components/add-setlist/setlist-performance.css.ts
@@ -1,0 +1,44 @@
+import { style } from '@vanilla-extract/css';
+
+import { themeVars } from '@confeti/design-system/styles';
+
+export const container = style({
+  ...themeVars.display.flexColumn,
+  width: '100%',
+  height: 'calc(100dvh - 1rem)',
+  padding: '2rem 2rem 0 2rem',
+  overflowY: 'auto',
+});
+
+export const title = style({
+  marginBottom: '2rem',
+
+  ...themeVars.fontStyles.body5_m_12,
+});
+
+export const performanceContainer = style({
+  flex: 1,
+  overflowY: 'auto',
+  display: 'grid',
+  gridTemplateColumns: 'repeat(3, 1fr)',
+  gridColumnGap: '1.8rem',
+  gridRowGap: '3rem',
+  paddingBottom: '10rem',
+});
+
+export const buttonSection = style({
+  position: 'fixed',
+  bottom: '0',
+  left: '0',
+  right: '0',
+  height: '9rem',
+  padding: '0 2rem',
+
+  background:
+    'linear-gradient(180deg, rgba(255, 255, 255, 0.00) 0%, #FFF 100%)',
+
+  zIndex: 100,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+});

--- a/apps/client/src/pages/my-history/components/add-setlist/setlist-performance.tsx
+++ b/apps/client/src/pages/my-history/components/add-setlist/setlist-performance.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+
+import { Button, FestivalCard } from '@confeti/design-system';
+import { SetListPerformance } from '@shared/types/my-history-response';
+
+import * as styles from './setlist-performance.css';
+
+interface Props {
+  performanceCount: number;
+  performances: SetListPerformance[];
+}
+
+const SetlistPerformance = ({ performanceCount, performances }: Props) => {
+  const [selectedFestivals, setSelectedFestivals] = useState<number[]>([]);
+
+  // TODO: 셋리스트 만들기 API 연동
+  const handleAddClick = () => {
+    console.log(selectedFestivals);
+  };
+
+  const handleFestivalSelect = (performanceId: number, isSelected: boolean) => {
+    setSelectedFestivals((prev) => {
+      if (isSelected) {
+        return [...prev, performanceId];
+      } else {
+        return prev.filter((id) => id !== performanceId);
+      }
+    });
+  };
+
+  return (
+    <div className={styles.container}>
+      <section className={styles.title}>
+        <p>{performanceCount}개의 검색결과</p>
+      </section>
+
+      <section className={styles.performanceContainer}>
+        {performances.map((performance) => {
+          const isSelected = selectedFestivals.includes(
+            performance.performanceId,
+          );
+
+          return (
+            <FestivalCard
+              key={performance.performanceId}
+              typeId={performance.performanceId}
+              title={performance.title}
+              imageSrc={performance.posterUrl}
+              selectable={true}
+              isSelected={isSelected}
+              onSelectChange={(_title, isSelected) =>
+                handleFestivalSelect(performance.performanceId, isSelected)
+              }
+            />
+          );
+        })}
+      </section>
+
+      <section className={styles.buttonSection}>
+        <Button
+          variant="add"
+          text={'셋리스트 만들기'}
+          disabled={selectedFestivals.length === 0}
+          onClick={handleAddClick}
+        />
+      </section>
+    </div>
+  );
+};
+
+export default SetlistPerformance;

--- a/apps/client/src/pages/my-history/components/preview/preview-section.tsx
+++ b/apps/client/src/pages/my-history/components/preview/preview-section.tsx
@@ -6,7 +6,7 @@ import { MyTimeTable } from '@shared/types/my-history-response';
 import * as styles from './preview-section.css';
 
 const routeMap = {
-  SET_LIST: '/setlist/add-setlist', // TODO: SET_LIST 실제 경로로 변경
+  SET_LIST: 'setlist/add-setlist',
   TIME_TABLE: '/timetable/add-festival',
 } as const;
 

--- a/apps/client/src/pages/my-history/page/add-setlist/add-setlist-page.css.ts
+++ b/apps/client/src/pages/my-history/page/add-setlist/add-setlist-page.css.ts
@@ -1,0 +1,15 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  height: '100vh',
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+export const searchBarContainer = style({
+  padding: '0 2rem 0 2rem',
+  display: 'flex',
+  alignItems: 'center',
+  width: '100%',
+  gap: '0.5rem',
+});

--- a/apps/client/src/pages/my-history/page/add-setlist/add-setlist-page.tsx
+++ b/apps/client/src/pages/my-history/page/add-setlist/add-setlist-page.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import SetlistPerformance from '@pages/my-history/components/add-setlist/setlist-performance';
+import { useRelatedSearch } from '@pages/search/hooks/use-search-data';
+
+import { SearchBar, SearchSuggestionList } from '@confeti/design-system';
+import { useDebouncedKeyword } from '@shared/hooks/use-debounce-keyword';
+import Loading from '@shared/pages/loading/loading';
+
+import { useSearchSetListPerformance } from '../hooks/use-performance-search';
+
+import * as styles from './add-setlist-page.css';
+
+const AddSetlistPage = () => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const paramsKeyword = searchParams.get('q') || '';
+
+  const { keyword, debouncedKeyword, handleInputChange } =
+    useDebouncedKeyword(paramsKeyword);
+
+  const [selectedKeyword, setSelectedKeyword] = useState<string | null>(null);
+  const [selectedType, setSelectedType] = useState<
+    'artist' | 'performance' | null
+  >(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const {
+    data: { relatedArtists, relatedPerformances },
+    isLoading: isRelatedSearchLoading,
+  } = useRelatedSearch({
+    keyword: debouncedKeyword,
+    enabled: !!debouncedKeyword.trim(),
+  });
+
+  const { data: setListPerformance, isLoading: isSetListPerformanceLoading } =
+    useSearchSetListPerformance(
+      {
+        aid: selectedType === 'artist' ? selectedId : null,
+        pid: selectedType === 'performance' ? Number(selectedId) : null,
+        term: selectedKeyword,
+      },
+      !!selectedKeyword,
+    );
+
+  useEffect(() => {
+    setSelectedKeyword(paramsKeyword);
+  }, [paramsKeyword]);
+
+  const handleSelectItem = (
+    keyword: string,
+    type: 'artist' | 'performance',
+    id: string,
+  ) => {
+    setSelectedKeyword(keyword);
+    setSelectedType(type);
+    setSelectedId(id);
+    navigate(`/my-history/setlist/add-setlist?q=${keyword}`);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !e.nativeEvent.isComposing && keyword.trim()) {
+      (e.target as HTMLInputElement).blur();
+    }
+  };
+
+  const handleInputChangeWithReset = (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    handleInputChange(e);
+    setSelectedKeyword(null);
+  };
+
+  const hasSearchResults =
+    (relatedArtists?.artists?.length ?? 0) > 0 ||
+    (relatedPerformances?.performances?.length ?? 0) > 0;
+
+  const renderSearchContent = () => {
+    const isLoadingState =
+      isSetListPerformanceLoading || isRelatedSearchLoading;
+    const isResultState = !!selectedKeyword;
+    const isSuggestionState = !selectedKeyword && hasSearchResults;
+
+    switch (true) {
+      case isLoadingState:
+        return <Loading />;
+
+      case isResultState:
+        return (
+          <SetlistPerformance
+            performanceCount={setListPerformance?.performanceCount ?? 0}
+            performances={setListPerformance?.performances ?? []}
+          />
+        );
+
+      case isSuggestionState:
+        return (
+          <>
+            <SearchSuggestionList
+              relatedKeyword={relatedArtists?.artists?.map((artist) => ({
+                id: artist.artistId,
+                title: artist.name,
+                profileUrl: artist.profileUrl,
+              }))}
+              onSelectKeyword={(keyword, id) =>
+                handleSelectItem(keyword, 'artist', id.toString())
+              }
+              listType="artist"
+            />
+            <SearchSuggestionList
+              relatedKeyword={relatedPerformances?.performances?.map(
+                (performance) => ({
+                  id: performance.id,
+                  title: performance.title,
+                  profileUrl: performance.posterUrl,
+                }),
+              )}
+              onSelectKeyword={(keyword, id) =>
+                handleSelectItem(keyword, 'performance', id.toString())
+              }
+              listType="performance"
+            />
+          </>
+        );
+
+      // TODO: default 처리
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.searchBarContainer}>
+        <SearchBar
+          placeholder="공연명 또는 아티스트를 검색해주세요."
+          value={keyword}
+          onChange={handleInputChangeWithReset}
+          onKeyDown={handleKeyDown}
+        />
+      </div>
+
+      {renderSearchContent()}
+    </div>
+  );
+};
+
+export default AddSetlistPage;

--- a/apps/client/src/pages/my-history/page/add-setlist/add-setlist-page.tsx
+++ b/apps/client/src/pages/my-history/page/add-setlist/add-setlist-page.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import SetlistPerformance from '@pages/my-history/components/add-setlist/setlist-performance';
-import { useRelatedSearch } from '@pages/search/hooks/use-search-data';
 
 import { SearchBar, SearchSuggestionList } from '@confeti/design-system';
 import { useDebouncedKeyword } from '@shared/hooks/use-debounce-keyword';
+import { useRelatedSearch } from '@shared/hooks/use-related-search';
 import Loading from '@shared/pages/loading/loading';
 
 import { useSearchSetListPerformance } from '../hooks/use-performance-search';

--- a/apps/client/src/pages/my-history/page/hooks/use-performance-search.ts
+++ b/apps/client/src/pages/my-history/page/hooks/use-performance-search.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { SETLIST_QUERY_OPTION } from '@shared/apis/my-history/setlist-queries';
+import { SetListPerformanceRequest } from '@shared/types/my-history-response';
+
+export const useSearchSetListPerformance = (
+  request: SetListPerformanceRequest,
+  enabled: boolean,
+) => {
+  const { data, isLoading } = useQuery({
+    ...SETLIST_QUERY_OPTION.SEARCH_PERFORMANCE(request, enabled),
+    enabled,
+  });
+
+  return { data, isLoading };
+};

--- a/apps/client/src/pages/search/hooks/use-search-data.ts
+++ b/apps/client/src/pages/search/hooks/use-search-data.ts
@@ -1,4 +1,4 @@
-import { useQueries, useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 
 import { SEARCH_ARTIST_QUERY_OPTION } from '@shared/apis/search/search-queries';
 import { IntendedPerformanceRequest } from '@shared/types/search-reponse';
@@ -16,25 +16,6 @@ export const useSearchArtist = ({ keyword, enabled }: KeywordProps) => {
   });
 
   return { data, isLoading };
-};
-
-export const useRelatedSearch = ({ keyword, enabled }: KeywordProps) => {
-  return useQueries({
-    queries: [
-      SEARCH_ARTIST_QUERY_OPTION.SEARCH_RELATED_KEYWORD(keyword, enabled),
-      SEARCH_PERFORMANCE_QUERY_OPTION.SEARCH_RELATED_PERFORMANCES(
-        keyword,
-        enabled,
-      ),
-    ],
-    combine: (results) => ({
-      data: {
-        relatedArtists: results[0].data,
-        relatedPerformances: results[1].data,
-      },
-      isLoading: results.some((r) => r.isLoading),
-    }),
-  });
 };
 
 export const usePerformanceTypeAnalysis = ({

--- a/apps/client/src/pages/search/page/search-page.tsx
+++ b/apps/client/src/pages/search/page/search-page.tsx
@@ -3,6 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 
 import { SearchBar, SearchSuggestionList } from '@confeti/design-system';
 import { useDebouncedKeyword } from '@shared/hooks/use-debounce-keyword';
+import { useRelatedSearch } from '@shared/hooks/use-related-search';
 import Loading from '@shared/pages/loading/loading';
 
 import PopularSearchSection from '../components/search-home/popular-search-section';
@@ -10,7 +11,6 @@ import RecentFestivalSection from '../components/search-home/recent-festivals-se
 import RecentSearchSection from '../components/search-home/recent-search-section';
 import {
   usePerformanceTypeAnalysis,
-  useRelatedSearch,
   useSearchArtist,
 } from '../hooks/use-search-data';
 import { useSearchLogic } from '../hooks/use-search-logic';

--- a/apps/client/src/shared/apis/my-history/setlist-queries.ts
+++ b/apps/client/src/shared/apis/my-history/setlist-queries.ts
@@ -1,0 +1,27 @@
+import { queryOptions } from '@tanstack/react-query';
+
+import { SetListPerformanceRequest } from '@shared/types/my-history-response';
+
+import { getSetListPerformance } from './setlist';
+
+export const SETLIST_QUERY_KEY = {
+  ALL: ['setlist'],
+  SEARCH_PERFORMANCE: (request: SetListPerformanceRequest) => [
+    ...SETLIST_QUERY_KEY.ALL,
+    'performance',
+    request,
+  ],
+};
+
+export const SETLIST_QUERY_OPTION = {
+  ALL: () =>
+    queryOptions({
+      queryKey: SETLIST_QUERY_KEY.ALL,
+    }),
+  SEARCH_PERFORMANCE: (request: SetListPerformanceRequest, enabled: boolean) =>
+    queryOptions({
+      queryKey: SETLIST_QUERY_KEY.SEARCH_PERFORMANCE(request),
+      queryFn: () => getSetListPerformance(request),
+      enabled,
+    }),
+};

--- a/apps/client/src/shared/apis/my-history/setlist.ts
+++ b/apps/client/src/shared/apis/my-history/setlist.ts
@@ -1,0 +1,24 @@
+import { BaseResponse } from '@shared/types/api';
+import {
+  SetListPerformanceRequest,
+  SetListPerformanceResponse,
+} from '@shared/types/my-history-response';
+
+import { get } from '../config/instance';
+
+export const getSetListPerformance = async (
+  request: SetListPerformanceRequest,
+): Promise<SetListPerformanceResponse> => {
+  const { pid, aid, term } = request;
+
+  const query = new URLSearchParams();
+
+  if (pid !== null) query.append('pid', String(pid));
+  if (aid !== null) query.append('aid', aid);
+  if (term !== null) query.append('term', term);
+
+  const url = `my/setlists/search/performances?${query.toString()}`;
+
+  const response = await get<BaseResponse<SetListPerformanceResponse>>(url);
+  return response.data;
+};

--- a/apps/client/src/shared/constants/path.ts
+++ b/apps/client/src/shared/constants/path.ts
@@ -17,8 +17,9 @@ export const routePath = {
 
   // MyHistory
   MY_HISTORY: '/my-history',
-  MY_HISTORY_OVERVIEW: 'overview',
   MY_HISTORY_REQUIRE_LOGIN: 'require-login',
+  MY_HISTORY_OVERVIEW: 'overview',
+  MY_HISTORY_ADD_SETLIST: 'setlist/add-setlist',
 
   // Search
   SEARCH: '/search',

--- a/apps/client/src/shared/hooks/use-related-search.ts
+++ b/apps/client/src/shared/hooks/use-related-search.ts
@@ -1,0 +1,30 @@
+import { useQueries } from '@tanstack/react-query';
+
+import {
+  SEARCH_ARTIST_QUERY_OPTION,
+  SEARCH_PERFORMANCE_QUERY_OPTION,
+} from '@shared/apis/search/search-queries';
+
+interface KeywordProps {
+  keyword: string;
+  enabled: boolean;
+}
+
+export const useRelatedSearch = ({ keyword, enabled }: KeywordProps) => {
+  return useQueries({
+    queries: [
+      SEARCH_ARTIST_QUERY_OPTION.SEARCH_RELATED_KEYWORD(keyword, enabled),
+      SEARCH_PERFORMANCE_QUERY_OPTION.SEARCH_RELATED_PERFORMANCES(
+        keyword,
+        enabled,
+      ),
+    ],
+    combine: (results) => ({
+      data: {
+        relatedArtists: results[0].data,
+        relatedPerformances: results[1].data,
+      },
+      isLoading: results.some((r) => r.isLoading),
+    }),
+  });
+};

--- a/apps/client/src/shared/router/lazy.ts
+++ b/apps/client/src/shared/router/lazy.ts
@@ -40,6 +40,9 @@ export const MyRecordPage = lazy(
 export const MyHistoryOverviewPage = lazy(
   () => import('@pages/my-history/page/overview/my-history-overview-page'),
 );
+export const AddSetlistPage = lazy(
+  () => import('@pages/my-history/page/add-setlist/add-setlist-page'),
+);
 
 // Search
 export const SearchPage = lazy(() => import('@pages/search/page/search-page'));

--- a/apps/client/src/shared/router/router.tsx
+++ b/apps/client/src/shared/router/router.tsx
@@ -5,6 +5,7 @@ import { routePath } from '@shared/constants/path';
 import GlobalLayout from './global-layout';
 import {
   AddFestivalPage,
+  AddSetlistPage,
   ConcertDetailPage,
   DeleteAccountPage,
   DeleteFestivalPage,
@@ -72,12 +73,16 @@ export default function Router() {
             element={createProtectedRoute(true, <MyRecordPage />)}
           />
           <Route
+            path={routePath.MY_HISTORY_REQUIRE_LOGIN}
+            element={<RequireLoginPage />}
+          />
+          <Route
             path={routePath.MY_HISTORY_OVERVIEW}
             element={<MyHistoryOverviewPage />}
           />
           <Route
-            path={routePath.MY_HISTORY_REQUIRE_LOGIN}
-            element={<RequireLoginPage />}
+            path={routePath.MY_HISTORY_ADD_SETLIST}
+            element={createProtectedRoute(true, <AddSetlistPage />)}
           />
         </Route>
 

--- a/apps/client/src/shared/types/my-history-response.ts
+++ b/apps/client/src/shared/types/my-history-response.ts
@@ -26,3 +26,20 @@ export interface MyHistoryRecord {
   timetableCount: number;
   setlistCount: number;
 }
+
+export interface SetListPerformance {
+  performanceId: number;
+  title: string;
+  posterUrl: string;
+}
+
+export interface SetListPerformanceResponse {
+  performanceCount: number;
+  performances: SetListPerformance[];
+}
+
+export interface SetListPerformanceRequest {
+  pid: number | null;
+  aid: string | null;
+  term: string | null;
+}

--- a/apps/client/src/shared/types/search-reponse.ts
+++ b/apps/client/src/shared/types/search-reponse.ts
@@ -38,7 +38,7 @@ export interface RelatedArtistResponse {
 }
 
 export interface RelatedPerformance {
-  id: string;
+  id: number;
   title: string;
   posterUrl: string;
 }

--- a/packages/design-system/src/components/search-suggestion-list/search-suggestion-list.tsx
+++ b/packages/design-system/src/components/search-suggestion-list/search-suggestion-list.tsx
@@ -3,7 +3,7 @@ import { CmpSearchArtistImg, CmpSearchImg } from '../../icons/src';
 import * as styles from './search-suggestion-list.css';
 
 interface KeywordProps {
-  id: string;
+  id: string | number;
   title: string;
   profileUrl: string;
 }
@@ -11,7 +11,7 @@ interface KeywordProps {
 interface SearchSuggestionListProps {
   relatedKeyword: KeywordProps[] | undefined;
   onSelectArtistId?: (id: string) => void;
-  onSelectKeyword?: (keyword: string) => void;
+  onSelectKeyword?: (keyword: string, id: string | number) => void;
   handleSearchParams?: () => void;
   listType?: 'artist' | 'performance';
 }
@@ -23,10 +23,10 @@ const SearchSuggestionList = ({
   handleSearchParams,
   listType,
 }: SearchSuggestionListProps) => {
-  const handleClick = (id: string, title: string) => {
+  const handleClick = (id: string | number, title: string) => {
     handleSearchParams?.();
-    onSelectArtistId?.(id);
-    onSelectKeyword?.(title);
+    onSelectArtistId?.(id.toString());
+    onSelectKeyword?.(title, id);
   };
 
   return (


### PR DESCRIPTION
## 📌 Summary

> - #427 

셋리스트 공연추가 페이지를 제작하고, 공연 추가를 위한 공연 검색 API를 연동했어요.

## 📚 Tasks

- 셋리스트 공연추가 페이지 뷰 제작
- 공연 추가를 위한 공연 검색 API 연동
- 연관검색어 처리 훅 shared 파일로 분리

## 👀 To Reviewer
코드가 많이 더러운데, 정말 바빠서 죄송합니다...
리소스가 많이 부족하네요. 페이지 구조는 기존 검색페이지와 비슷한 형식입니다.
커스텀 훅으로 로직을 분리하지 않은 이유는 반드시 리팩토링이 필요하다고 생각했고, 스프린트 끝나면 검색로직에서 공통 부분을 빼서 커스텀 훅으로 제작하기 위함입니다.




## 📸 Screenshot
<img width="371" alt="스크린샷 2025-04-28 오전 4 39 05" src="https://github.com/user-attachments/assets/f80bfb3d-a3b9-4480-a7c0-2036e815773a" />

