### PR TITLE
Feat(client): 최근 본 공연 기능 구현

### DIFF
--- a/apps/client/src/pages/performance/page/concert-detail.tsx
+++ b/apps/client/src/pages/performance/page/concert-detail.tsx
@@ -11,6 +11,7 @@ import { useConcertDetail } from '@pages/performance/hooks/use-concert-detail';
 
 import { FloatingButton, Footer, Spacing } from '@confeti/design-system';
 import { useScrollPosition } from '@shared/hooks/use-scroll-position';
+import { addRecentViewItem } from '@shared/utils/recent-view';
 
 const ConcertDetailPage = () => {
   const { typeId } = useParams<{ typeId: string }>();
@@ -19,6 +20,10 @@ const ConcertDetailPage = () => {
   const concertDetail = useConcertDetail(parsedConcertId);
   const { concert } = concertDetail;
   const { isButtonHidden } = useScrollPosition();
+
+  if (concert.concertId) {
+    addRecentViewItem({ type: 'concert', typeId: concert.concertId });
+  }
 
   useEffect(() => {
     if (concertDetail.concertArtists.length >= 4) {

--- a/apps/client/src/pages/performance/page/festival-detail.tsx
+++ b/apps/client/src/pages/performance/page/festival-detail.tsx
@@ -10,6 +10,7 @@ import { useFestivalDetail } from '@pages/performance/hooks/use-festival-detail'
 
 import { FloatingButton, Footer, Spacing } from '@confeti/design-system';
 import { useScrollPosition } from '@shared/hooks/use-scroll-position';
+import { addRecentViewItem } from '@shared/utils/recent-view';
 
 const FestivalDetailPage = () => {
   const { typeId } = useParams<{ typeId: string }>();
@@ -17,6 +18,10 @@ const FestivalDetailPage = () => {
   const festivalDetail = useFestivalDetail(parsedFestivalId);
   const { festival } = festivalDetail;
   const { isButtonHidden } = useScrollPosition();
+
+  if (festival.festivalId) {
+    addRecentViewItem({ type: 'festival', typeId: festival.festivalId });
+  }
 
   return (
     <>

--- a/apps/client/src/pages/search/components/search-home/recent-festivals-section.tsx
+++ b/apps/client/src/pages/search/components/search-home/recent-festivals-section.tsx
@@ -1,10 +1,14 @@
 import { FestivalCard } from '@confeti/design-system';
-import { PERFORMANCE_DATA } from '@shared/mocks/performance-data';
+import { RecentPerformanceViewResponse } from '@shared/types/search-reponse';
 
 import * as styles from './recent-festivals-section.css';
 
-export default function RecentFestivalSection() {
-  const performances = PERFORMANCE_DATA.performances;
+interface Props {
+  recentViewData: RecentPerformanceViewResponse;
+}
+
+export default function RecentFestivalSection({ recentViewData }: Props) {
+  const performances = recentViewData.performances;
   const hasRecentlyViewed = performances.length > 0;
 
   return (
@@ -13,7 +17,7 @@ export default function RecentFestivalSection() {
       {hasRecentlyViewed ? (
         <ul className={styles.list}>
           {performances.map((festival) => (
-            <li key={festival.typeId} className={styles.item}>
+            <li key={festival.performanceId} className={styles.item}>
               <FestivalCard
                 typeId={festival.typeId}
                 title={festival.title}

--- a/apps/client/src/pages/search/hooks/use-search-data.ts
+++ b/apps/client/src/pages/search/hooks/use-search-data.ts
@@ -1,9 +1,11 @@
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 
 import { SEARCH_ARTIST_QUERY_OPTION } from '@shared/apis/search/search-queries';
+import {
+  SEARCH_PAGE_QUERY_OPTION,
+  SEARCH_PERFORMANCE_QUERY_OPTION,
+} from '@shared/apis/search/search-queries';
 import { IntendedPerformanceRequest } from '@shared/types/search-reponse';
-
-import { SEARCH_PERFORMANCE_QUERY_OPTION } from './../../../shared/apis/search/search-queries';
 
 interface KeywordProps {
   keyword: string;
@@ -48,7 +50,15 @@ export const useIntendedPerformance = ({
 
 export const usePopularSearch = () => {
   const { data } = useSuspenseQuery({
-    ...SEARCH_ARTIST_QUERY_OPTION.SEARCH_POPULAR_SEARCH(),
+    ...SEARCH_PAGE_QUERY_OPTION.SEARCH_POPULAR_SEARCH(),
+  });
+
+  return { data };
+};
+
+export const useRecentView = (items: string) => {
+  const { data } = useSuspenseQuery({
+    ...SEARCH_PAGE_QUERY_OPTION.RECENT_VIEW(items),
   });
 
   return { data };

--- a/apps/client/src/pages/search/page/search-page.tsx
+++ b/apps/client/src/pages/search/page/search-page.tsx
@@ -5,6 +5,7 @@ import { SearchBar, SearchSuggestionList } from '@confeti/design-system';
 import { useDebouncedKeyword } from '@shared/hooks/use-debounce-keyword';
 import { useRelatedSearch } from '@shared/hooks/use-related-search';
 import Loading from '@shared/pages/loading/loading';
+import { getRecentViewItems } from '@shared/utils/recent-view';
 
 import PopularSearchSection from '../components/search-home/popular-search-section';
 import RecentFestivalSection from '../components/search-home/recent-festivals-section';
@@ -13,6 +14,7 @@ import { useRecentSearch } from '../hooks/use-recent-search';
 import {
   usePerformanceTypeAnalysis,
   usePopularSearch,
+  useRecentView,
   useSearchArtist,
 } from '../hooks/use-search-data';
 import { useSearchLogic } from '../hooks/use-search-logic';
@@ -40,6 +42,11 @@ const SearchPage = () => {
     enabled: !!paramsKeyword,
   });
   const { data: popularSearchData } = usePopularSearch();
+  const recentViewItems = getRecentViewItems();
+  const items = recentViewItems
+    .map((item) => `${item.type}:${item.typeId}`)
+    .join(',');
+  const { data: recentViewData } = useRecentView(items);
 
   const {
     data: { relatedArtists, relatedPerformances },
@@ -114,7 +121,7 @@ const SearchPage = () => {
           <main className={styles.resultSection}>
             <RecentSearchSection />
             <PopularSearchSection popularSearchData={popularSearchData} />
-            <RecentFestivalSection />
+            <RecentFestivalSection recentViewData={recentViewData} />
           </main>
         );
     }

--- a/apps/client/src/shared/apis/search/search-queries.ts
+++ b/apps/client/src/shared/apis/search/search-queries.ts
@@ -9,7 +9,31 @@ import {
   getPerformanceRelatedKeyword,
   getPerformanceTypeAnalysis,
   getPopularSearch,
+  getRecentView,
 } from './search';
+
+export const SEARCH_PAGE_QUERY_KEY = {
+  ALL: ['search'],
+  SEARCH_POPULAR_SEARCH: () => [...SEARCH_PAGE_QUERY_KEY.ALL, 'popular'],
+  RECENT_VIEW: (items: string) => [
+    ...SEARCH_PAGE_QUERY_KEY.ALL,
+    'recent',
+    items,
+  ],
+} as const;
+
+export const SEARCH_PAGE_QUERY_OPTION = {
+  ALL: () => queryOptions({ queryKey: SEARCH_PAGE_QUERY_KEY.ALL }),
+  SEARCH_POPULAR_SEARCH: () => ({
+    queryKey: SEARCH_PAGE_QUERY_KEY.SEARCH_POPULAR_SEARCH(),
+    // TODO: limit 상수 처리
+    queryFn: () => getPopularSearch(10),
+  }),
+  RECENT_VIEW: (items: string) => ({
+    queryKey: SEARCH_PAGE_QUERY_KEY.RECENT_VIEW(items),
+    queryFn: () => getRecentView(items),
+  }),
+};
 
 export const SEARCH_ARTIST_QUERY_KEY = {
   ALL: ['artist'],
@@ -18,7 +42,6 @@ export const SEARCH_ARTIST_QUERY_KEY = {
     'search',
     keyword,
   ],
-  SEARCH_POPULAR_SEARCH: () => [...SEARCH_ARTIST_QUERY_KEY.ALL, 'popular'],
 } as const;
 
 export const SEARCH_ARTIST_QUERY_OPTION = {
@@ -32,11 +55,6 @@ export const SEARCH_ARTIST_QUERY_OPTION = {
     queryKey: SEARCH_ARTIST_QUERY_KEY.SEARCH_ARTIST(keyword),
     queryFn: () => getArtistRelatedKeyword(keyword),
     enabled,
-  }),
-  SEARCH_POPULAR_SEARCH: () => ({
-    queryKey: SEARCH_ARTIST_QUERY_KEY.SEARCH_POPULAR_SEARCH(),
-    // TODO: limit 상수 처리
-    queryFn: () => getPopularSearch(10),
   }),
 };
 

--- a/apps/client/src/shared/apis/search/search.ts
+++ b/apps/client/src/shared/apis/search/search.ts
@@ -7,6 +7,7 @@ import {
   IntendedPerformanceResponse,
   PerformanceTypeAnalysis,
   PopularSearchResponse,
+  RecentPerformanceViewResponse,
   RelatedArtistResponse,
   RelatedPerformanceResponse,
 } from '@shared/types/search-reponse';
@@ -72,5 +73,14 @@ export const getPopularSearch = async (
     `${END_POINT.GET_POPULAR_SEARCH(limit)}`,
   );
 
+  return response.data;
+};
+
+export const getRecentView = async (
+  items: string,
+): Promise<RecentPerformanceViewResponse> => {
+  const response = await get<BaseResponse<RecentPerformanceViewResponse>>(
+    `${END_POINT.GET_RECENT_VIEW(items)}`,
+  );
   return response.data;
 };

--- a/apps/client/src/shared/constants/api.ts
+++ b/apps/client/src/shared/constants/api.ts
@@ -60,6 +60,7 @@ export const END_POINT = {
   GET_PERFORMANCE_TYPE_ANALYSIS: (keyword: string) =>
     `performances/search/type-analysis?term=${encodeURIComponent(keyword)}`,
   GET_POPULAR_SEARCH: (limit: number) => `search/terms/popular?limit=${limit}`,
+  GET_RECENT_VIEW: (items: string) => `performances/expected?items=${items}`,
 
   //로그인,로그아웃,토큰재발급
   POST_SOCIAL_LOGIN: 'auth/login',

--- a/apps/client/src/shared/types/search-reponse.ts
+++ b/apps/client/src/shared/types/search-reponse.ts
@@ -84,3 +84,15 @@ export interface PopularSearch {
 export interface PopularSearchResponse {
   popularTerms: PopularSearch[];
 }
+
+export interface RecentPerformanceView {
+  performanceId: number;
+  typeId: number;
+  type: 'FESTIVAL' | 'CONCERT' | 'ARTIST';
+  title: string;
+  posterUrl: string;
+}
+
+export interface RecentPerformanceViewResponse {
+  performances: RecentPerformanceView[];
+}

--- a/apps/client/src/shared/utils/recent-view.ts
+++ b/apps/client/src/shared/utils/recent-view.ts
@@ -1,0 +1,27 @@
+const RECENT_VIEW_KEY = 'recentView';
+
+interface RecentViewItem {
+  type: 'concert' | 'festival';
+  typeId: number;
+}
+
+export const addRecentViewItem = (item: RecentViewItem) => {
+  if (typeof window === 'undefined') return;
+
+  const stored = localStorage.getItem(RECENT_VIEW_KEY);
+  const parsed: RecentViewItem[] = stored ? JSON.parse(stored) : [];
+
+  const filtered = parsed.filter(
+    (i) => !(i.type === item.type && i.typeId === item.typeId),
+  );
+
+  const updated = [item, ...filtered];
+
+  localStorage.setItem(RECENT_VIEW_KEY, JSON.stringify(updated));
+};
+
+export const getRecentViewItems = (): RecentViewItem[] => {
+  if (typeof window === 'undefined') return [];
+  const stored = localStorage.getItem(RECENT_VIEW_KEY);
+  return stored ? JSON.parse(stored) : [];
+};


### PR DESCRIPTION
## 📌 Summary

> - #433

최근 본 공연 기능을 구현했어요.

## 📚 Tasks

- 유효한 콘서트/페스티벌 목록 조회 API 연동
- 최근 본 공연 기능 구현

## 👀 To Reviewer
최근 본 공연을 로컬스토리지에 저장하고(유틸 함수로 구현), 저장한 type과 typeId를 서버로 전달해요.
해당 공연이 유효한지(날짜가 지났는지 등) 서버와의 통신을 통해 확인한 후 받은 데이터를 출력하는 기능입니다.


## 📸 Screenshot
<img width="365" alt="스크린샷 2025-04-28 오후 6 05 54" src="https://github.com/user-attachments/assets/40e5dc12-f677-40ff-a39c-ee10fa6faf0c" />

