### PR TITLE
Feat(client): 셋리스트 공연 추가 API 연동

### DIFF
--- a/apps/client/src/pages/my-history/components/add-setlist/setlist-performance.tsx
+++ b/apps/client/src/pages/my-history/components/add-setlist/setlist-performance.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAddPerformanceMutation } from '@pages/my-history/hooks/use-add-performance-mutation';
 
 import { Button, FestivalCard } from '@confeti/design-system';
+import { routePath } from '@shared/constants/path';
 import { SetListPerformance } from '@shared/types/my-history-response';
 
 import * as styles from './setlist-performance.css';
@@ -11,19 +14,30 @@ interface Props {
 }
 
 const SetlistPerformance = ({ performanceCount, performances }: Props) => {
-  const [selectedFestivals, setSelectedFestivals] = useState<number[]>([]);
+  const navigate = useNavigate();
+  const [selectedFestivals, setSelectedFestivals] = useState<
+    Pick<SetListPerformance, 'type' | 'typeId'>[]
+  >([]);
 
-  // TODO: 셋리스트 만들기 API 연동
+  const { mutate: addPerformanceToSetList } = useAddPerformanceMutation();
+
+  // TODO: 1개 추가, 여러개 추가시 네비게이션 추가 필요
+  // 1개 추가 -> 해당 공연의 셋리스트 페이지로 이동
+  // 여러개 추가 -> 셋리스트 초기 페이지로 이동(현재 적용상태)
   const handleAddClick = () => {
-    console.log(selectedFestivals);
+    addPerformanceToSetList(selectedFestivals, {
+      onSuccess: () => {
+        navigate(routePath.MY_HISTORY);
+      },
+    });
   };
 
-  const handleFestivalSelect = (performanceId: number, isSelected: boolean) => {
+  const handleFestivalSelect = (typeId: number, isSelected: boolean) => {
     setSelectedFestivals((prev) => {
       if (isSelected) {
-        return [...prev, performanceId];
+        return [...prev, { type: 'FESTIVAL', typeId }];
       } else {
-        return prev.filter((id) => id !== performanceId);
+        return prev.filter((item) => item.typeId !== typeId);
       }
     });
   };
@@ -36,20 +50,20 @@ const SetlistPerformance = ({ performanceCount, performances }: Props) => {
 
       <section className={styles.performanceContainer}>
         {performances.map((performance) => {
-          const isSelected = selectedFestivals.includes(
-            performance.performanceId,
+          const isSelected = selectedFestivals.some(
+            (item) => item.typeId === performance.performanceId,
           );
 
           return (
             <FestivalCard
               key={performance.performanceId}
-              typeId={performance.performanceId}
+              typeId={performance.typeId}
               title={performance.title}
               imageSrc={performance.posterUrl}
               selectable={true}
               isSelected={isSelected}
               onSelectChange={(_title, isSelected) =>
-                handleFestivalSelect(performance.performanceId, isSelected)
+                handleFestivalSelect(performance.typeId, isSelected)
               }
             />
           );

--- a/apps/client/src/pages/my-history/components/preview/preview-section.tsx
+++ b/apps/client/src/pages/my-history/components/preview/preview-section.tsx
@@ -1,7 +1,10 @@
 import { useNavigate } from 'react-router-dom';
 
 import { Box, Button, FestivalCard } from '@confeti/design-system';
-import { MyTimeTable } from '@shared/types/my-history-response';
+import {
+  MyHistorySetList,
+  MyTimeTable,
+} from '@shared/types/my-history-response';
 
 import * as styles from './preview-section.css';
 
@@ -15,7 +18,7 @@ interface Props {
   title: string;
   showMore?: boolean;
   buttonLabel?: string;
-  previewData?: MyTimeTable[];
+  previewData?: MyHistorySetList[] | MyTimeTable[];
   emptyMessage: string;
   ctaText: string;
   navigatePath?: string;

--- a/apps/client/src/pages/my-history/hooks/use-add-performance-mutation.ts
+++ b/apps/client/src/pages/my-history/hooks/use-add-performance-mutation.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { postAddPerformanceToSetList } from '@shared/apis/my-history/setlist';
+import { SETLIST_QUERY_KEY } from '@shared/apis/my-history/setlist-queries';
+import { SetListPerformance } from '@shared/types/my-history-response';
+
+export const useAddPerformanceMutation = () => {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (items: Pick<SetListPerformance, 'type' | 'typeId'>[]) =>
+      postAddPerformanceToSetList(items),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: [...SETLIST_QUERY_KEY.ALL],
+      });
+    },
+  });
+  return mutation;
+};

--- a/apps/client/src/pages/my-history/page/record/my-record.tsx
+++ b/apps/client/src/pages/my-history/page/record/my-record.tsx
@@ -46,8 +46,7 @@ const MyRecord = () => {
       <PreviewSection
         previewType="SET_LIST"
         title="My 셋리스트"
-        //TODO : ? 키워드 관련 이슈 => 빈 값일 경우 서버에서 반환 값 통일 요청
-        previewData={setListPreviewData.setlists?.slice(0, 3)}
+        previewData={setListPreviewData}
         emptyMessage="아직 My 셋리스트가 없어요."
         ctaText="셋리스트 추가하기"
         navigatePath={`${routePath.MY_HISTORY_OVERVIEW}?type=SET_LIST`}

--- a/apps/client/src/shared/apis/my-history/my-history.ts
+++ b/apps/client/src/shared/apis/my-history/my-history.ts
@@ -3,6 +3,7 @@ import { SortOption } from '@shared/constants/sort-label';
 import { BaseResponse } from '@shared/types/api';
 import {
   MyHistoryRecord,
+  MyHistorySetList,
   MyHistorySetListResponse,
   MyHistoryTimetableResponse,
 } from '@shared/types/my-history-response';
@@ -24,9 +25,10 @@ export const getMyTimeTableOverView = async (sortBy: SortOption) => {
 };
 
 export const getMySetListPreview = async () => {
-  const response = await get<BaseResponse<MyHistorySetListResponse>>(
+  const response = await get<BaseResponse<MyHistorySetList[]>>(
     END_POINT.GET_MY_SET_LIST,
   );
+
   return response.data;
 };
 

--- a/apps/client/src/shared/apis/my-history/setlist.ts
+++ b/apps/client/src/shared/apis/my-history/setlist.ts
@@ -1,10 +1,12 @@
+import { END_POINT } from '@shared/constants/api';
 import { BaseResponse } from '@shared/types/api';
 import {
+  SetListPerformance,
   SetListPerformanceRequest,
   SetListPerformanceResponse,
 } from '@shared/types/my-history-response';
 
-import { get } from '../config/instance';
+import { get, post } from '../config/instance';
 
 export const getSetListPerformance = async (
   request: SetListPerformanceRequest,
@@ -20,5 +22,16 @@ export const getSetListPerformance = async (
   const url = `my/setlists/search/performances?${query.toString()}`;
 
   const response = await get<BaseResponse<SetListPerformanceResponse>>(url);
+  return response.data;
+};
+
+export const postAddPerformanceToSetList = async (
+  items: Pick<SetListPerformance, 'type' | 'typeId'>[],
+) => {
+  const response = await post<BaseResponse<void>>(
+    END_POINT.POST_ADD_PERFORMANCE_TO_SET_LIST,
+    items,
+  );
+
   return response.data;
 };

--- a/apps/client/src/shared/constants/api.ts
+++ b/apps/client/src/shared/constants/api.ts
@@ -17,6 +17,9 @@ export const END_POINT = {
   GET_MY_SET_LIST: '/my/setlists/preview',
   GET_MY_SET_LIST_OVERVIEW: (sortBy: SortOption) =>
     `/my/setlists/all?sortBy=${sortBy}`,
+  POST_ADD_PERFORMANCE_TO_SET_LIST: '/my/setlists',
+
+  // 마이페이지
   GET_USER_PROFILE: '/user/info',
   GET_MY_UPCOMING_PERFORMANCE: '/user/favorites/performance',
   GET_MY_ARTISTS_PREVIEW: '/user/favorites/artists/preview',

--- a/apps/client/src/shared/types/my-history-response.ts
+++ b/apps/client/src/shared/types/my-history-response.ts
@@ -31,6 +31,8 @@ export interface SetListPerformance {
   performanceId: number;
   title: string;
   posterUrl: string;
+  type: 'FESTIVAL' | 'CONCERT';
+  typeId: number;
 }
 
 export interface SetListPerformanceResponse {


### PR DESCRIPTION
## 📌 Summary

> - #429 

셋리스트 공연 추가 API를 연동했어요.

## 📚 Tasks

- 셋리스트 공연 추가 API 연동

## 👀 To Reviewer
주석으로 적어두긴했는데
셋리스트에 공연을 추가할 때 1개 추가, 여러개 추가시 네비게이션 요구사항이 달라요.
- 1개 추가 -> 해당 공연의 셋리스트 페이지로 이동
- 여러개 추가 -> 셋리스트 초기 페이지로 이동(현재 적용상태)

셋리스트 상세페이지가 나오면 연동 부탁드려요. (1개 추가 case)