### PR TITLE
Fix(client): 토큰 재발급 로직 수정

### DIFF
--- a/apps/client/src/shared/apis/config/interceptor.ts
+++ b/apps/client/src/shared/apis/config/interceptor.ts
@@ -17,6 +17,7 @@ import { axiosInstance } from './instance';
 
 const redirectToHome = () => {
   authTokenHandler('remove');
+  window.location.replace(routePath.ROOT);
   throw new Error('인증에 실패했습니다. 다시 로그인해주세요.');
 };
 

--- a/apps/client/src/shared/apis/config/interceptor.ts
+++ b/apps/client/src/shared/apis/config/interceptor.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/react';
 import { AxiosError, InternalAxiosRequestConfig } from 'axios';
 import Cookies from 'js-cookie';
 
-import { END_POINT, HTTP_STATUS_CODE } from '@shared/constants/api';
+import { CONFIG, END_POINT, HTTP_STATUS_CODE } from '@shared/constants/api';
 import { routePath } from '@shared/constants/path';
 import {
   ACCESS_TOKEN_KEY,
@@ -13,7 +13,7 @@ import { TokenResponse } from '@shared/types/login-response';
 import { authTokenHandler } from '@shared/utils/token-handler';
 
 import { HTTPError } from './http-error';
-import { axiosInstance, post } from './instance';
+import { axiosInstance } from './instance';
 
 const redirectToHome = () => {
   authTokenHandler('remove');
@@ -49,12 +49,15 @@ export const handleAPIError = async (error: AxiosError<ErrorResponse>) => {
 
   switch (status) {
     case HTTP_STATUS_CODE.UNAUTHORIZED:
-    case HTTP_STATUS_CODE.NOT_FOUND:
       try {
         return await handleTokenError(error);
       } catch (tokenError) {
         throw new HTTPError(status, '인증 토큰 갱신에 실패했습니다.');
       }
+
+    case HTTP_STATUS_CODE.NOT_FOUND:
+      throw new HTTPError(status, '요청하신 리소스를 찾을 수 없습니다.');
+
     default:
       if (status >= HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR) {
         throw new HTTPError(status, '서버 내부 오류가 발생했습니다.');
@@ -77,24 +80,30 @@ export const handleTokenError = async (error: AxiosError<ErrorResponse>) => {
   }
 
   try {
-    const response = await post<BaseResponse<TokenResponse>>(
-      END_POINT.POST_REISSUE_TOKEN,
-      null,
+    const response = await fetch(
+      `${CONFIG.BASE_URL}${END_POINT.POST_REISSUE_TOKEN}`,
       {
+        method: 'POST',
         headers: {
           Authorization: `Bearer ${refreshToken}`,
+          'Content-Type': 'application/json',
         },
+        credentials: 'include',
       },
     );
 
+    if (!response.ok) throw new Error('토큰 재발급 실패');
+
+    const result: BaseResponse<TokenResponse> = await response.json();
     const { accessToken: newAccessToken, refreshToken: newRefreshToken } =
-      response.data;
+      result.data;
+
     authTokenHandler('set', newAccessToken, newRefreshToken);
 
     const originalConfig = error.config;
     originalConfig.headers['Authorization'] = `Bearer ${newAccessToken}`;
     return axiosInstance(originalConfig);
-  } catch (error) {
+  } catch (err) {
     return redirectToHome();
   }
 };
@@ -105,6 +114,5 @@ export const handleCheckAndSetToken = (config: InternalAxiosRequestConfig) => {
   if (accessToken && config.headers) {
     config.headers['Authorization'] = `Bearer ${accessToken}`;
   }
-
   return config;
 };

--- a/apps/client/src/shared/apis/config/interceptor.ts
+++ b/apps/client/src/shared/apis/config/interceptor.ts
@@ -17,7 +17,6 @@ import { axiosInstance } from './instance';
 
 const redirectToHome = () => {
   authTokenHandler('remove');
-  window.location.replace(routePath.ROOT);
   throw new Error('인증에 실패했습니다. 다시 로그인해주세요.');
 };
 
@@ -103,7 +102,7 @@ export const handleTokenError = async (error: AxiosError<ErrorResponse>) => {
     const originalConfig = error.config;
     originalConfig.headers['Authorization'] = `Bearer ${newAccessToken}`;
     return axiosInstance(originalConfig);
-  } catch (err) {
+  } catch (error) {
     return redirectToHome();
   }
 };


### PR DESCRIPTION
## 📌 Summary

> - #440 

토큰 재발급 로직을 수정했어요.

## 📚 Tasks

- 토큰 재발급 로직을 수정

## 👀 To Reviewer

원인 1. 404인 경우에도 불필요한 토큰 재발급이 발생했음.
-> 401일 경우에만 재발급 받도록 수정

원인 2. 토큰 재발급시에 기존 인터셉터가 적용된 axiosInstance를 사용함. 그래서 헤더에 refreshToken이 아닌 accessToken이 넘어갔음.
-> fetch 사용하도록 수정
