### PR TITLE
Fix(client): 타임테이블 보드 레이아웃 수정

### DIFF
--- a/apps/client/src/pages/time-table/components/time-table-board/time-cell.css.ts
+++ b/apps/client/src/pages/time-table/components/time-table-board/time-cell.css.ts
@@ -14,7 +14,7 @@ export const timeP = recipe({
   base: {
     ...themeVars.fontStyles.body5_r_12,
     padding: '0 0.4rem',
-    marginRight: '0.7rem',
+    marginRight: '1.1rem',
     backgroundColor: themeVars.color.white,
   },
   variants: {

--- a/apps/client/src/pages/time-table/components/time-table-board/time-table-item.css.ts
+++ b/apps/client/src/pages/time-table/components/time-table-board/time-table-item.css.ts
@@ -20,7 +20,7 @@ export const itemsWrapper = recipe({
     zIndex: themeVars.zIndex.timeTable.content,
     cursor: 'pointer',
     transition: 'background-color 0.18s ease-out',
-    minWidth: '10.2rem',
+    minWidth: '10.3rem',
     boxSizing: 'border-box',
     margin: 0,
     padding: '0.5rem',

--- a/apps/client/src/pages/time-table/components/time-table-board/time-table-item.tsx
+++ b/apps/client/src/pages/time-table/components/time-table-board/time-table-item.tsx
@@ -67,7 +67,7 @@ const TimeTableItem = ({
     onClick(userTimetableId, !selectBlock);
   };
 
-  const top = `calc(${(minutesFromOpen / totalFestivalMinutes) * 100}% + 0.7rem)`;
+  const top = `calc(${(minutesFromOpen / totalFestivalMinutes) * 98.6}% + 0.7rem)`;
   const height = `calc((${totalPerformMin} / ${totalFestivalMinutes}) * 100%)`;
 
   const dynamicVars = assignInlineVars({

--- a/apps/client/src/pages/time-table/utils/index.ts
+++ b/apps/client/src/pages/time-table/utils/index.ts
@@ -17,6 +17,7 @@ export const parseTimeString = (timeString: string): string[] => {
   return [hour, min];
 };
 
+// TODO: 추후 수정 필요, 사용 안되고 있음
 export const calcPosition = (totalMin: number, minutesFromOpen: number) => {
   const top = (minutesFromOpen / 5) * TIME_SLOT_HEIGHT_5_MIN;
   const diff = (totalMin / 5) * TIME_SLOT_HEIGHT_5_MIN;


### PR DESCRIPTION
## 📌 Summary

> - #482


## 📚 Tasks

- 타임테이블 보드 레이아웃 수정

## 📸 Screenshot
<table>
  <tr>
    <td>
      <strong>전</strong><br />
<img width="425" alt="스크린샷 2025-04-30 오후 3 53 52" src="https://github.com/user-attachments/assets/b2389687-8b19-4e91-969a-26b7ffcf9d20" />
    </td>
    <td>
      <strong>후</strong><br />
<img width="429" alt="스크린샷 2025-04-30 오후 3 52 53" src="https://github.com/user-attachments/assets/9e76c3c1-5b35-4a9a-a5b0-d98f71302eba" />
    </td>
  </tr>
</table>