### PR TITLE
Fix(client): empty-festival 컴포넌트 뷰 수정

### DIFF
--- a/apps/client/src/pages/time-table/components/empty/empty-festival-section.css.ts
+++ b/apps/client/src/pages/time-table/components/empty/empty-festival-section.css.ts
@@ -4,12 +4,10 @@ import { themeVars } from '@confeti/design-system/styles';
 
 export const container = style({
   ...themeVars.display.flexColumnAlignTextCenter,
-  position: 'absolute',
-  top: '50%',
-  left: '50%',
+  justifyContent: 'center',
   width: '100%',
+  height: '90svh',
   gap: '2.4rem',
-  transform: 'translate(-50%, -50%)',
 });
 
 export const iconDescriptionWrapper = style({


### PR DESCRIPTION
## 📌 Summary

- #489 

## 📚 Tasks

- 모바일에서 position 이 absolute로 잡혀있어서 뷰가 무너지는 현상을 고쳤어요

<!--
## 👀 To Reviewer

(기재 내용 없을 경우 섹션 삭제) 더 전달할 내용 혹은 리뷰에게 요청하는 내용을 작성해주세요.
-->

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/9ae24bfb-03d1-4ca7-b2ac-69ad1d822d45)
