### PR TITLE
Fix(design-system): 음악 아이템 제목의 최대 너비 및 너비 설정 추가

### DIFF
--- a/packages/design-system/src/components/music-item/music-item.css.ts
+++ b/packages/design-system/src/components/music-item/music-item.css.ts
@@ -54,6 +54,8 @@ export const textSection = style({
 
 export const title = style({
   ...themeVars.fontStyles.title4_b_16,
+  maxWidth: '21rem',
+  width: '100%',
   color: themeVars.color.gray800,
   overflow: 'hidden',
   whiteSpace: 'nowrap',


### PR DESCRIPTION
## 📌 Summary

- #492 

## 📚 Tasks

- _해당 PR에 수행한 작업을 작성해주세요._

## 👀 To Reviewer

  textOverflow: 'ellipsis' 가 설정되어있지만, max-width값이 없어서 적용이 안되고 있었어요 해당 사항 변경해서 적용합니다.


## 📸 Screenshot
전
![image](https://github.com/user-attachments/assets/37a2eede-073f-4a77-a111-cac02531fdc4)


후

![image](https://github.com/user-attachments/assets/522d3b11-8e65-4519-a0da-0850ccaf449e)



