### PR TITLE
refactor: Hero 컴포넌트에서 posterBgUrl 제거 및 posterUrl로 통합

### DIFF
--- a/apps/client/src/pages/performance/page/concert-detail.tsx
+++ b/apps/client/src/pages/performance/page/concert-detail.tsx
@@ -34,7 +34,6 @@ const ConcertDetailPage = () => {
   return (
     <>
       <Hero
-        posterBgUrl={concert.posterBgUrl}
         posterUrl={concert.posterUrl}
         title={concert.title}
         startAt={concert.startAt}

--- a/apps/client/src/pages/performance/page/festival-detail.tsx
+++ b/apps/client/src/pages/performance/page/festival-detail.tsx
@@ -27,7 +27,6 @@ const FestivalDetailPage = () => {
     <>
       <FloatingButton isButtonHidden={isButtonHidden} />
       <Hero
-        posterBgUrl={festival.posterBgUrl}
         posterUrl={festival.posterUrl}
         title={festival.title}
         startAt={festival.startAt}

--- a/apps/client/src/shared/components/hero/hero.tsx
+++ b/apps/client/src/shared/components/hero/hero.tsx
@@ -4,25 +4,18 @@ import { formatDate } from '@shared/utils/format-date';
 import * as styles from './hero.css';
 
 interface HeroProps {
-  posterBgUrl: string;
   posterUrl: string;
   title: string;
   startAt: string;
   onClickBack?: () => void;
 }
 
-const Hero = ({
-  posterBgUrl,
-  posterUrl,
-  title,
-  startAt,
-  onClickBack,
-}: HeroProps) => {
+const Hero = ({ posterUrl, title, startAt, onClickBack }: HeroProps) => {
   const year = formatDate(startAt, 'koHalf').split('년')[0];
 
   return (
     <div className={styles.wrapper}>
-      <img src={posterBgUrl} className={styles.background} alt="배경 포스터" />
+      <img src={posterUrl} className={styles.background} alt="배경 포스터" />
       <div className={styles.backgroundOverlay} />
       <button className={styles.backButton} onClick={onClickBack}>
         <IcArrowLeftWhite20 width="2rem" height="2rem" />


### PR DESCRIPTION
## 📌 Summary

> -#498

## 📚 Tasks

- 서버의 제안으로 리소스 낭비를 줄이기 위해 Hero 컴포넌트에서 posterBgUrl을 제거하고 posterUrl 하나로 배경과 포스터 이미지를 통합했습니다. 결과물은 동일합니다!

<!--
## 👀 To Reviewer

(기재 내용 없을 경우 섹션 삭제) 더 전달할 내용 혹은 리뷰에게 요청하는 내용을 작성해주세요.
-->

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요. 필요시 .gif 형식으로 첨부해주세요.
-->
