### PR TITLE
Fix(design-system): (QA/5) 음악 아이템 아티스트 제목의 최대 너비 및 너비 설정 추가

### DIFF
--- a/packages/design-system/src/components/music-item/music-item.css.ts
+++ b/packages/design-system/src/components/music-item/music-item.css.ts
@@ -66,6 +66,8 @@ export const title = style({
 export const artist = style({
   ...themeVars.fontStyles.body4_m_13,
   color: themeVars.color.gray600,
+  width: '100%',
+  maxWidth: '21rem',
   overflow: 'hidden',
   whiteSpace: 'nowrap',
   textOverflow: 'ellipsis',


### PR DESCRIPTION
## 📌 Summary

- #500 


## 📚 Tasks

- 홈 페이지에 있는 음악 리스트에서 가수명이 길어질 경우 스크롤 밖으로 나가는 현상을 수정합니다.

## 👀 To Reviewer

- max-width는 피그마 기준으로 설정했고, width를 100%로 주어서 문제해결했어요

## 📸 Screenshot

https://github.com/user-attachments/assets/dfc8c2d9-5588-4c67-8b95-6a9f31d61dd5

### after

![image](https://github.com/user-attachments/assets/bcab59e1-27c1-42d7-bfb1-4d150518160e)

