### PR TITLE
Fix(client): 타임테이블 픽셀 밀림 현상 해결

### DIFF
--- a/apps/client/src/pages/time-table/components/time-table-board/time-cell.css.ts
+++ b/apps/client/src/pages/time-table/components/time-table-board/time-cell.css.ts
@@ -6,7 +6,7 @@ import { themeVars } from '@confeti/design-system/styles';
 export const timeList = style({
   display: 'flex',
   alignItems: 'center',
-  paddingBottom: '3rem',
+  marginBottom: '3.65rem',
   zIndex: themeVars.zIndex.timeTable.row,
 });
 
@@ -14,7 +14,7 @@ export const timeP = recipe({
   base: {
     ...themeVars.fontStyles.body5_r_12,
     padding: '0 0.4rem',
-    marginRight: '1.1rem',
+    marginRight: '1rem',
     backgroundColor: themeVars.color.white,
   },
   variants: {

--- a/apps/client/src/pages/time-table/components/time-table-board/time-table-board.css.ts
+++ b/apps/client/src/pages/time-table/components/time-table-board/time-table-board.css.ts
@@ -15,9 +15,9 @@ export const container = style({
   },
   msOverflowStyle: 'none',
   scrollbarWidth: 'none',
-  paddingTop: '1.2rem',
+  paddingTop: '2.3rem',
   overflowY: 'visible',
-  marginBottom: '9rem',
+  marginBottom: '10rem',
 });
 
 export const wrapper = recipe({
@@ -37,9 +37,9 @@ export const wrapper = recipe({
 
 export const stagesContainer = style({
   display: 'flex',
-  width: 'calc(100% - 2.9rem)',
+  width: 'calc(100% - 3rem)',
   position: 'absolute',
-  left: '2.9rem',
+  left: '3rem',
   top: 0,
   bottom: 0,
   backgroundColor: themeVars.color.white,
@@ -47,7 +47,7 @@ export const stagesContainer = style({
 
 export const timeList = style({
   ...themeVars.display.flexAlignCenter,
-  marginBottom: '2.2rem',
+  marginBottom: '2.3rem',
   backgroundColor: themeVars.color.white,
 });
 
@@ -84,6 +84,7 @@ export const stageColumn = style({
   flex: 1,
   minWidth: '10.2rem',
   position: 'relative',
+  top: '5px',
 });
 
 export const stagesWrapper = style({

--- a/apps/client/src/pages/time-table/components/time-table-board/time-table-item.tsx
+++ b/apps/client/src/pages/time-table/components/time-table-board/time-table-item.tsx
@@ -58,8 +58,6 @@ const TimeTableItem = ({
     openMin,
   );
 
-  const totalFestivalMinutes = calcTotalFestivalMinutes(openHour, openMin);
-
   const handleSetSelectedBlock = () => {
     if (isEditTimeTableMode) {
       setSelectBlock((prev) => !prev);
@@ -67,8 +65,10 @@ const TimeTableItem = ({
     onClick(userTimetableId, !selectBlock);
   };
 
-  const top = `calc(${(minutesFromOpen / totalFestivalMinutes) * 98.6}% + 0.7rem)`;
-  const height = `calc((${totalPerformMin} / ${totalFestivalMinutes}) * 100%)`;
+  const pixelsPerMinute = 1.5;
+
+  const top = `${minutesFromOpen * pixelsPerMinute}px`;
+  const height = `${totalPerformMin * pixelsPerMinute}px`;
 
   const dynamicVars = assignInlineVars({
     [styles.top]: top,
@@ -88,7 +88,7 @@ const TimeTableItem = ({
         {artists.map((artist) => artist.artistName).join(', ')}
       </div>
       <div className={styles.durationP({ isSelected: selectBlock })}>
-        {`${startHour}:${startMin}-${endHour}:${endMin}`}
+        {`${startHour}:${startMin} -${endHour}:${endMin} `}
         {`(${totalPerformMin}min)`}
       </div>
     </div>

--- a/apps/client/src/pages/time-table/page/time-table-page.css.ts
+++ b/apps/client/src/pages/time-table/page/time-table-page.css.ts
@@ -8,29 +8,6 @@ export const wrapper = style({
   overflowY: 'auto', // Y축 스크롤 허용
 });
 
-export const actionsWrapper = style({
-  display: 'flex',
-  padding: '2rem',
-  gap: '0.8rem',
-  background: themeVars.color.white_grad,
-  position: 'fixed',
-  bottom: 0,
-  left: '50%',
-  transform: 'translateX(-50%)',
-  width: 'min(100%, var(--max-width))',
-  maxWidth: '100%',
-  zIndex: themeVars.zIndex.timeTableActions.content,
-});
-
-export const downloadButton = style({
-  padding: '0rem',
-});
-
-export const editButton = style({
-  color: themeVars.color.confeti_lime2,
-  backgroundColor: themeVars.color.gray800,
-});
-
 export const timeTableWrapper = style({
   maxWidth: '47.7rem',
   backgroundColor: themeVars.color.white,


### PR DESCRIPTION
## 📌 Summary

> - #508 


## 📚 Tasks

- 


## 👀 To Reviewer

<img width="407" alt="스크린샷 2025-05-09 오후 6 54 08" src="https://github.com/user-attachments/assets/1163e7ff-a7b0-435c-9e71-db97b0c7bcb8" />

타임테이블 관련해서 수정하던 도중 애초에 스타일에 결함이 있다는걸 깨달았어요.
10분당 15px로 계산되지 않고 있더라고요. 대충보면 맞아보이지만 의도된 디자인과는 크게 벗어나기에 정확히 높이를 계산할 수 있도록 수정했어요.


수정 후

<img width="401" alt="스크린샷 2025-05-09 오후 6 54 29" src="https://github.com/user-attachments/assets/dda3314e-b7e6-4341-a44f-a6fc31c1ff98" />

하지만 계속해서 px밀림 현상이 일어나고 있어요... 후반부 시간대로가면 계속해서 조금씩 밀리더라구요.
정확한 간격을 계산했지만, 해당 부분에 대해서는 계속 살펴봐도 감이 안잡혀서... @seueooo 님이 이어서 해주실겁니다. 부탁해요 😅


## 📸 Screenshot


