### PR TITLE
Feat(client): UI 관련 QA 반영

### DIFF
--- a/apps/client/src/pages/my-history/components/add-setlist/setlist-performance.css.ts
+++ b/apps/client/src/pages/my-history/components/add-setlist/setlist-performance.css.ts
@@ -25,6 +25,7 @@ export const performanceContainer = style({
   columnGap: '1.8rem',
   maxWidth: 'fit-content',
   maxHeight: 'fit-content',
+  paddingBottom: '8rem',
 });
 
 export const festivalCardWrapper = style({

--- a/apps/client/src/pages/my-history/components/record/record-info.tsx
+++ b/apps/client/src/pages/my-history/components/record/record-info.tsx
@@ -19,7 +19,7 @@ const RecordInfo = ({
       </div>
       <div className={styles.item}>
         <h4 className={styles.title}>나의 타임테이블</h4>
-        <p className={styles.count}>{totalTimeTable}명</p>
+        <p className={styles.count}>{totalTimeTable}개</p>
       </div>
       <div className={styles.item}>
         <h4 className={styles.title}>나의 셋리스트</h4>

--- a/apps/client/src/pages/my-history/components/record/record-introduce.tsx
+++ b/apps/client/src/pages/my-history/components/record/record-introduce.tsx
@@ -12,7 +12,12 @@ const RecordIntroduce = ({ name, profileUrl }: Props) => {
 
   return (
     <section className={styles.wrapper}>
-      <Avatar src={profileUrl} alt={`${name}의 프로필 이미지`} size="xl" />
+      <Avatar
+        src={profileUrl}
+        alt={`${name}의 프로필 이미지`}
+        size="xl"
+        isHandleClick={false}
+      />
 
       <div className={styles.info}>
         <div className={styles.sectionWrapper}>

--- a/apps/client/src/pages/my/components/profile/user-info.css.ts
+++ b/apps/client/src/pages/my/components/profile/user-info.css.ts
@@ -39,12 +39,9 @@ export const title = style({
 export const titleWrapper = style({
   ...themeVars.display.flexAlignCenter,
   gap: '0.2rem',
+  cursor: 'pointer',
 });
 
 export const titlePostfix = style({
   ...themeVars.fontStyles.body1_r_16,
-});
-
-export const arrowIcon = style({
-  cursor: 'pointer',
 });

--- a/apps/client/src/pages/my/components/profile/user-info.tsx
+++ b/apps/client/src/pages/my/components/profile/user-info.tsx
@@ -44,17 +44,10 @@ const UserInfo = ({
       </div>
 
       <div className={styles.userInfo}>
-        <div className={styles.titleWrapper}>
+        <div className={styles.titleWrapper} onClick={handleClick}>
           <h2 className={styles.title}>{name}</h2>
           <p className={styles.titlePostfix}>{USER_POSTFIX}</p>
-          {showArrow && (
-            <IcArrowGray16
-              className={styles.arrowIcon}
-              onClick={handleClick}
-              width={'1.6rem'}
-              height={'1.6rem'}
-            />
-          )}
+          {showArrow && <IcArrowGray16 width={'1.6rem'} height={'1.6rem'} />}
         </div>
       </div>
     </div>

--- a/apps/client/src/pages/onboarding/components/artist-select.css.ts
+++ b/apps/client/src/pages/onboarding/components/artist-select.css.ts
@@ -29,6 +29,7 @@ export const avatarGridSection = style({
   columnGap: '4.7rem',
   alignItems: 'center',
   justifyItems: 'center',
+  paddingBottom: '1.2rem',
 });
 
 export const avatar = style({

--- a/apps/client/src/pages/onboarding/components/artist-select.css.ts
+++ b/apps/client/src/pages/onboarding/components/artist-select.css.ts
@@ -29,7 +29,7 @@ export const avatarGridSection = style({
   columnGap: '4.7rem',
   alignItems: 'center',
   justifyItems: 'center',
-  paddingBottom: '1.2rem',
+  paddingBottom: '3rem',
 });
 
 export const avatar = style({

--- a/apps/client/src/pages/performance/components/reservation/reservation.css.ts
+++ b/apps/client/src/pages/performance/components/reservation/reservation.css.ts
@@ -42,6 +42,7 @@ export const logo = style({
   height: '100%',
   objectFit: 'cover',
   borderRadius: 'inherit',
+  transform: 'scale(1.03)',
 });
 
 export const name = style({

--- a/apps/client/src/pages/time-table/page/delete-festival/delete-festival-dialogs.tsx
+++ b/apps/client/src/pages/time-table/page/delete-festival/delete-festival-dialogs.tsx
@@ -19,9 +19,12 @@ export const ConfirmDialog = ({
   <Dialog open={isOpen} handleClose={onClose}>
     <Dialog.Content>
       <Dialog.Title>
-        <span className={cn(className)}>{numberToDelete + ' '}</span>개의 공연을
-        삭제할까요?
+        <span className={cn(className)} style={{ marginRight: '0.2rem' }}>
+          {numberToDelete}
+        </span>
+        개의 공연을 삭제할까요?
       </Dialog.Title>
+
       <Dialog.Description>
         <p>제작했던 타임테이블은</p>
         <p>&apos;내 공연&apos; 페이지에서 다시 볼 수 있어요.</p>

--- a/packages/design-system/src/components/avatar/avatar.css.ts
+++ b/packages/design-system/src/components/avatar/avatar.css.ts
@@ -85,7 +85,16 @@ export const imgVariants = recipe({
     height: '100%',
     borderRadius: '100%',
     objectFit: 'cover',
-    cursor: 'pointer',
+  },
+  variants: {
+    isClickable: {
+      true: {
+        cursor: 'pointer',
+      },
+      false: {
+        cursor: 'default',
+      },
+    },
   },
 });
 

--- a/packages/design-system/src/components/avatar/avatar.tsx
+++ b/packages/design-system/src/components/avatar/avatar.tsx
@@ -38,7 +38,9 @@ const Avatar = ({
   };
 
   const renderFallback = !src && !fallback && (
-    <CmpProfileNon className={styles.imgVariants()} />
+    <CmpProfileNon
+      className={styles.imgVariants({ isClickable: isHandleClick })}
+    />
   );
 
   return (
@@ -48,7 +50,11 @@ const Avatar = ({
       onClick={handleClick}
     >
       {src ? (
-        <img src={src} alt={alt} className={styles.imgVariants()} />
+        <img
+          src={src}
+          alt={alt}
+          className={styles.imgVariants({ isClickable: isHandleClick })}
+        />
       ) : (
         renderFallback || <span className={styles.fallback()}>{fallback}</span>
       )}

--- a/packages/design-system/src/components/footer/footer.tsx
+++ b/packages/design-system/src/components/footer/footer.tsx
@@ -2,36 +2,51 @@ import { LogoFooter } from '../../icons/src';
 
 import * as styles from './footer.css';
 
-const list = {
-  companyInfo: [
-    { label: '대표', value: '김가연' },
-    { label: '이메일', value: 'weareconfeti@gmail.com' },
-  ],
-  legalInfo: [{ label: '개인정보처리방침' }, { label: '이용약관' }],
-} as const;
+const Footer = () => {
+  const list = {
+    companyInfo: [
+      { label: '대표', value: '김가연' },
+      { label: '이메일', value: 'weareconfeti@gmail.com' },
+    ],
+    legalInfo: [
+      {
+        label: '개인정보처리방침',
+        href: 'https://wonderful-celestite-e3c.notion.site/confeti-1b4210e281b080e5ad4ad28c651a651a',
+      },
+      {
+        label: '이용약관',
+        href: 'https://wonderful-celestite-e3c.notion.site/confeti-1b3210e281b08080b766f48bf18d0be9',
+      },
+    ],
+  } as const;
 
-const Footer = () => (
-  <footer className={styles.container}>
-    <div className={styles.logoSection}>
-      <LogoFooter className={styles.logo} />
-    </div>
+  return (
+    <footer className={styles.container}>
+      <div className={styles.logoSection}>
+        <LogoFooter className={styles.logo} />
+      </div>
 
-    <div className={styles.textSection}>
-      <ul className={styles.left}>
-        {list.companyInfo.map((item, index) => (
-          <li key={index}>
-            {item.label} | {item.value}
-          </li>
-        ))}
-      </ul>
+      <div className={styles.textSection}>
+        <ul className={styles.left}>
+          {list.companyInfo.map((item, index) => (
+            <li key={index}>
+              {item.label} | {item.value}
+            </li>
+          ))}
+        </ul>
 
-      <ul className={styles.right}>
-        {list.legalInfo.map((item, index) => (
-          <li key={index}>{item.label}</li>
-        ))}
-      </ul>
-    </div>
-  </footer>
-);
+        <ul className={styles.right}>
+          {list.legalInfo.map((item, index) => (
+            <li key={index}>
+              <a href={item.href} target="_blank" rel="noopener noreferrer">
+                {item.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </footer>
+  );
+};
 
 export default Footer;

--- a/packages/design-system/src/components/performance-carousel/performance-carousel.css.ts
+++ b/packages/design-system/src/components/performance-carousel/performance-carousel.css.ts
@@ -63,6 +63,7 @@ export const imgDiv = style({
   height: '100%',
   flexShrink: '0',
   padding: '0 0.5rem',
+  cursor: 'pointer',
 });
 
 export const infoOverlay = style({


### PR DESCRIPTION
## 📌 Summary

> - #514 

## 📚 Tasks
다른 파트의 확인이 필요한 UI 이슈 QA 말고는 다 해놓았습니다! 셋리스트 관련 ui는 어떤 공연을 추가해도 저주에 걸려버려서 확인을 할 수가 없네요

- 프로필 수정 터치 영역 늘림
- 내 공연 > 콘페티 기록 부분에서 프로필 사진 체크 안 되게 수정
- 온보딩, 내 공연 검색 아래 여백 추가 (자체 QA 진행 ^^,,, 수진이한테 오마카세 진행하고 컨펌받음)
- 예매처 바로가기 이미지 확대 (스크린샷은 슬랙에서 확인)
- 타임테이블 라이팅 (명-> 개) 수정
- 홈 > performance 캐러셀 커서 pointer 적용
- 타임테이블 삭제 모달 숫자와 개 사이에 공백 추가
- 푸터 이용약관, 개인정보처리방침 링크 이동

## 👀 To Reviewer
1. 내 공연 - 콘페티 기록에서 프로필 Avatar 컴포넌트의 체크가 비활성화되도록 수정하면서 해당 상태에서 cursor가 여전히 pointer로 표시되는 UX 흐름이 어색하다고 판단되어 cursor 스타일도 함께 제어되도록 Avatar 컴포넌트를 수정했습니다.
2. 내 공연 검색 섹션에서 버튼과 제목이 겹치는 이슈가 있어 하단 여백을 추가하여 분리되도록 수정했습니다. 온보딩 화면에서도 아티스트 이름과 버튼 사이가 붙어 있어 답답한 느낌이 있길래... 아래 여백 추가했습니다! 
3. YES24 예매처가 배포된 사이트에서는 좌우 여백이 보이더라구요. 확대한 후에도 그러는지는 배포 후에 테스트 해보겠습니다 🥲
4. 이 PR에 마이페이지 쪼잔 qa도 해서 넣을게요 저녁에...

## 📸 Screenshot
<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/544c0811-2908-4875-830e-41de16dd34ec" width="300" /></td>
    <td><img src="https://github.com/user-attachments/assets/bce6276d-b14f-4e20-a99d-7afb0583b33e" width="300" /></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/81052f56-7a9c-4672-a8dd-ce0e1ad45732" width="300" /></td>
    <td><img src="https://github.com/user-attachments/assets/f477f6b8-b189-460d-a2c7-f5d452f5c690" width="300" /></td>
  </tr>
<tr>
<td><img width="430" alt="스크린샷 2025-05-12 오후 1 25 58" src="https://github.com/user-attachments/assets/93dab60b-0523-4cd6-90da-13852f17530c" /></td>
<td><img width="428" alt="스크린샷 2025-05-12 오후 1 50 08" src="https://github.com/user-attachments/assets/56c4c3c9-3966-42e6-911d-e728d3d73f4f" /></td>
</tr>
</table>

https://github.com/user-attachments/assets/b69aa955-85ab-4245-8e31-1ec44c671f81

