### PR TITLE
Fix(client): 내 공연 관련 버그 수정

### DIFF
--- a/apps/client/src/pages/my-history/components/add-setlist/setlist-performance.tsx
+++ b/apps/client/src/pages/my-history/components/add-setlist/setlist-performance.tsx
@@ -32,10 +32,14 @@ const SetlistPerformance = ({ performanceCount, performances }: Props) => {
     });
   };
 
-  const handleFestivalSelect = (typeId: number, isSelected: boolean) => {
+  const handleFestivalSelect = (
+    typeId: number,
+    isSelected: boolean,
+    type: 'FESTIVAL' | 'CONCERT',
+  ) => {
     setSelectedFestivals((prev) => {
       if (isSelected) {
-        return [...prev, { type: 'FESTIVAL', typeId }];
+        return [...prev, { type, typeId }];
       } else {
         return prev.filter((item) => item.typeId !== typeId);
       }
@@ -49,29 +53,26 @@ const SetlistPerformance = ({ performanceCount, performances }: Props) => {
       </section>
 
       <section className={styles.performanceContainer}>
-        {performances.map((performance) => {
-          const isSelected = selectedFestivals.some(
-            (item) => item.typeId === performance.performanceId,
-          );
-
-          return (
-            <div
-              key={performance.performanceId}
-              className={styles.festivalCardWrapper}
-            >
-              <FestivalCard
-                typeId={performance.typeId}
-                title={performance.title}
-                imageSrc={performance.posterUrl}
-                selectable={true}
-                isSelected={isSelected}
-                onSelectChange={(_title, isSelected) =>
-                  handleFestivalSelect(performance.typeId, isSelected)
-                }
-              />
-            </div>
-          );
-        })}
+        {performances.map((performance) => (
+          <div key={performance.typeId} className={styles.festivalCardWrapper}>
+            <FestivalCard
+              typeId={performance.typeId}
+              title={performance.title}
+              imageSrc={performance.posterUrl}
+              selectable={true}
+              isSelected={selectedFestivals.some(
+                (item) => item.typeId === performance.typeId,
+              )}
+              onSelectChange={(_title, isSelected) =>
+                handleFestivalSelect(
+                  performance.typeId,
+                  isSelected,
+                  performance.type,
+                )
+              }
+            />
+          </div>
+        ))}
       </section>
 
       <section className={styles.buttonSection}>

--- a/apps/client/src/pages/my-history/components/preview/preview-section.tsx
+++ b/apps/client/src/pages/my-history/components/preview/preview-section.tsx
@@ -55,6 +55,10 @@ const PreviewSection = ({
     navigate(buildPath(routePath.MY_HISTORY_SETLIST_DETAIL, { setlistId }));
   };
 
+  const handleNavigateToTimeTable = () => {
+    navigate(routePath.TIME_TABLE_OUTLET);
+  };
+
   const renderPreviewList = () => {
     if (!previewData || previewData.length === 0) return null;
 
@@ -76,6 +80,7 @@ const PreviewSection = ({
         typeId={previewData.typeId}
         title={previewData.title}
         imageSrc={previewData.posterUrl}
+        onClick={handleNavigateToTimeTable}
       />
     ));
   };

--- a/apps/client/src/pages/my-history/components/setlist-detail/setlist-empty.tsx
+++ b/apps/client/src/pages/my-history/components/setlist-detail/setlist-empty.tsx
@@ -11,7 +11,7 @@ const SetListEmpty = () => {
   const { setlistId } = useParams<{ setlistId: string }>();
   const handleClickAddMusic = () => {
     navigate(
-      buildPath(routePath.MY_HISTORY_ADD_SONGS, {
+      buildPath(routePath.MY_HISTORY_ADD_SONGS_ABSOLUTE, {
         setlistId: setlistId ?? '',
       }),
     );

--- a/apps/client/src/pages/my-history/components/setlist-detail/setlist-tracks.tsx
+++ b/apps/client/src/pages/my-history/components/setlist-detail/setlist-tracks.tsx
@@ -88,7 +88,6 @@ const SetListTracks = ({
       })),
     [localTracks],
   );
-  console.log(mappedTracks);
 
   const { musicList, onClickPlayToggle, audioRef } =
     useMusicPlayer(mappedTracks);

--- a/apps/client/src/pages/my-history/page/add-songs/confirm-add-section.tsx
+++ b/apps/client/src/pages/my-history/page/add-songs/confirm-add-section.tsx
@@ -76,7 +76,7 @@ const ConfirmAddSection = ({
     addMusicToSetListMutation.mutate(requestData);
 
     navigate(
-      buildPath(routePath.MY_HISTORY_SETLIST_DETAIL, {
+      buildPath(routePath.MY_HISTORY_SETLIST_DETAIL_ABSOLUTE, {
         setlistId: setlistId ?? '',
       }),
     );

--- a/apps/client/src/pages/my-history/page/overview/my-history-overview-page.tsx
+++ b/apps/client/src/pages/my-history/page/overview/my-history-overview-page.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import CountDisplay from '@pages/my-history/components/overview/count-display';
 import OrderByButton from '@pages/my-history/components/overview/order-by-button';
 import {
@@ -13,6 +13,8 @@ import {
   SORT_OPTIONS,
   SortOption,
 } from '@shared/constants/sort-label';
+import { routePath } from '@shared/router/path';
+import { buildPath } from '@shared/utils/build-path';
 
 import * as styles from './my-history-overview-page.css';
 
@@ -22,6 +24,7 @@ const MyHistoryOverviewPage = () => {
   const [searchParams] = useSearchParams();
   const type = searchParams.get('type');
   const isSetList = type === 'SET_LIST';
+  const navigate = useNavigate();
   const { data: setListOverviewData } = useMySetListOverView(
     sortOption,
     isSetList,
@@ -47,6 +50,16 @@ const MyHistoryOverviewPage = () => {
     );
   };
 
+  const handleNavigateToDetail = (setlistId: number) => {
+    navigate(
+      buildPath(routePath.MY_HISTORY_SETLIST_DETAIL_ABSOLUTE, { setlistId }),
+    );
+  };
+
+  const handleNavigateToTimeTable = () => {
+    navigate(`${routePath.TIME_TABLE_OUTLET}`);
+  };
+
   return (
     <>
       <Header
@@ -62,14 +75,27 @@ const MyHistoryOverviewPage = () => {
           />
         </div>
         <div className={styles.gridContainer}>
-          {overviewData.data?.map((item) => (
-            <FestivalCard
-              key={item.typeId}
-              typeId={item.typeId}
-              imageSrc={item.posterUrl}
-              title={item.title}
-            />
-          ))}
+          {isSetList
+            ? setListOverviewData?.setlists?.map((item) => (
+                <FestivalCard
+                  key={item.typeId}
+                  type={item.type}
+                  typeId={item.typeId}
+                  imageSrc={item.posterUrl}
+                  title={item.title}
+                  onClick={() => handleNavigateToDetail(item.setlistId)}
+                />
+              ))
+            : timetableOverviewData?.timetables?.map((item) => (
+                <FestivalCard
+                  key={item.typeId}
+                  type={item.type}
+                  typeId={item.typeId}
+                  imageSrc={item.posterUrl}
+                  title={item.title}
+                  onClick={handleNavigateToTimeTable}
+                />
+              ))}
         </div>
       </section>
     </>

--- a/apps/client/src/pages/my-history/page/setlist-detail/setlist-detail.tsx
+++ b/apps/client/src/pages/my-history/page/setlist-detail/setlist-detail.tsx
@@ -37,7 +37,7 @@ const SetListDetailPage = () => {
   const { mutate: reorderSetList } = useReorderSetList();
 
   const handleClickAdd = () => {
-    navigate(buildPath(routePath.MY_HISTORY_ADD_SONGS, { setlistId }));
+    navigate(buildPath(routePath.MY_HISTORY_ADD_SONGS_ABSOLUTE, { setlistId }));
   };
 
   const handleStartEdit = () => {

--- a/apps/client/src/shared/router/path.ts
+++ b/apps/client/src/shared/router/path.ts
@@ -24,6 +24,7 @@ export const routePath = {
   MY_HISTORY_ADD_SONGS: 'setlist/:setlistId/add-songs',
   MY_HISTORY_SETLIST_DETAIL: 'setlist-detail/:setlistId',
   MY_HISTORY_SETLIST_DETAIL_ABSOLUTE: '/my-history/setlist-detail/:setlistId',
+  MY_HISTORY_ADD_SONGS_ABSOLUTE: '/my-history/setlist/:setlistId/add-songs',
 
   // Search
   SEARCH: '/search',

--- a/apps/client/src/shared/router/path.ts
+++ b/apps/client/src/shared/router/path.ts
@@ -23,6 +23,7 @@ export const routePath = {
   MY_HISTORY_ADD_SETLIST: 'setlist/add-setlist',
   MY_HISTORY_ADD_SONGS: 'setlist/:setlistId/add-songs',
   MY_HISTORY_SETLIST_DETAIL: 'setlist-detail/:setlistId',
+  MY_HISTORY_SETLIST_DETAIL_ABSOLUTE: '/my-history/setlist-detail/:setlistId',
 
   // Search
   SEARCH: '/search',

--- a/apps/client/src/shared/types/my-history-response.ts
+++ b/apps/client/src/shared/types/my-history-response.ts
@@ -1,6 +1,9 @@
 import { Performances } from './performance-response';
 
-export type MyTimeTable = Pick<Performances, 'typeId' | 'posterUrl' | 'title'>;
+export type MyTimeTable = Pick<
+  Performances,
+  'typeId' | 'posterUrl' | 'title' | 'type'
+>;
 
 export interface MyHistoryTimetableResponse {
   timetableCount: number;

--- a/packages/design-system/src/components/festival-card/festival-card.tsx
+++ b/packages/design-system/src/components/festival-card/festival-card.tsx
@@ -28,7 +28,7 @@ const FestivalCard = ({
 }: FestivalCardProps) => {
   const [internalSelected, setInternalSelected] = useState(isSelected);
   const navigate = useNavigate();
-  const detailRoutePath = `/${type}-detail/${typeId}`;
+  const detailRoutePath = `/${type?.toLowerCase()}-detail/${typeId}`;
 
   const handleClick = () => {
     if (selectable) {


### PR DESCRIPTION
## 📌 Summary

> - #517 

내 공연 페이지에서 발생하는 버그들을 수정했어요.

## 📚 Tasks

- My 타임테이블내 FestivalCard 클릭시 타임테이블 페이지로 이동
- My 셋리스트내 FestivalCard 클릭시 셋리스트 상세 페이지로 이동
- 내 공연 검색후 공연 추가시 type이 고정되어있는 문제 해결
- 중첩라우팅으로 인해 내 공연에서 buildPath가 제대로 작동하지 않는 문제 해결
  - path.ts내에 절대경로를 추가로 생성해서 해결했어요. 더 나은 방법이 있다면 제안해주세요 !


## 👀 To Reviewer
<img width="422" alt="스크린샷 2025-05-17 오후 10 24 13" src="https://github.com/user-attachments/assets/54d4c0bd-e92f-4e30-902f-b7fda4a01d12" />

내 공연 페이지의 해당 섹션들과 

<img width="423" alt="스크린샷 2025-05-17 오후 10 24 39" src="https://github.com/user-attachments/assets/e8206bfb-6591-4b88-8987-51e685e3dad8" />
<img width="424" alt="스크린샷 2025-05-17 오후 10 24 53" src="https://github.com/user-attachments/assets/36d22b91-a255-4f07-99f7-e658f87c55d7" />

해당 페이지들이 동일한 UI를 공유하지만 내부 로직은 조금 달라요. (라우팅 되는 부분, 데이터, ...)
그래서 조건부로 분리를 하는 방식으로 구현이 되어있는데 이게 맞는지 의문이 드네요. 같은 UI를 공유하지만 각 페이지 내에서 요구사항이 변경된다면 또 조건부로 구현을 해줘야한다는 문제가 생길 수 있어요.
의견을 받겠습니다!!!

---

추가로 
<img width="411" alt="스크린샷 2025-05-17 오후 10 28 28" src="https://github.com/user-attachments/assets/e8eb0e92-43f5-4629-9e07-acf05a0db94a" />

여기 FestivalCard로 클릭을하면 타임테이블 페이지로 이동을 하도록 수정은 했는데, 포커스가 항상 첫번째로 맞춰진다는 이슈가 있어요. 이걸 그냥 두는게 좋을지 해결을 하는게 좋을지도 의견이 궁금합니다.
