### PR TITLE
Fix(client): 페스티벌 추가 갯수 수정 및 toast 이벤트 수정

### DIFF
--- a/apps/client/src/pages/time-table/constants/index.ts
+++ b/apps/client/src/pages/time-table/constants/index.ts
@@ -2,4 +2,4 @@ export const HALF_HOUR_TO_MINUTES = 30;
 export const TIME_SLOT_HEIGHT_5_MIN = 0.75;
 export const ONE_HOUR_TO_MINUTES = 60;
 export const END_HOUR = 24;
-export const MAX_SELECTIONS = 3;
+export const MAX_SELECTIONS = 5;

--- a/apps/client/src/pages/time-table/page/add-festival/add-festival.tsx
+++ b/apps/client/src/pages/time-table/page/add-festival/add-festival.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAddTimeTableFestival } from '@pages/time-table/hooks/use-timetable-festival-mutation';
 
@@ -24,12 +25,14 @@ const AddFestival = () => {
   });
   const TOTAL_SELECTIONS = selectedFestivals.length + addedFestivals.length;
 
-  const handleAddClick = () => {
-    if (TOTAL_SELECTIONS > MAX_SELECTIONS) {
+  useEffect(() => {
+    if (TOTAL_SELECTIONS >= MAX_SELECTIONS) {
       showToast();
-    } else {
-      addFestival(selectedFestivals);
     }
+  }, [selectedFestivals, TOTAL_SELECTIONS, showToast]);
+
+  const handleAddClick = () => {
+    addFestival(selectedFestivals);
   };
 
   return (
@@ -64,7 +67,9 @@ const AddFestival = () => {
         <Button
           variant="add"
           text={'추가하기'}
-          disabled={selectedFestivals.length === 0}
+          disabled={
+            selectedFestivals.length === 0 || TOTAL_SELECTIONS >= MAX_SELECTIONS
+          }
           onClick={handleAddClick}
         />
       </div>

--- a/apps/client/src/pages/time-table/page/add-festival/add-festival.tsx
+++ b/apps/client/src/pages/time-table/page/add-festival/add-festival.tsx
@@ -24,6 +24,8 @@ const AddFestival = () => {
     navigate(routePath.TIME_TABLE_OUTLET);
   });
   const TOTAL_SELECTIONS = selectedFestivals.length + addedFestivals.length;
+  const isButtonDisabled =
+    selectedFestivals.length === 0 || TOTAL_SELECTIONS >= MAX_SELECTIONS;
 
   useEffect(() => {
     if (TOTAL_SELECTIONS >= MAX_SELECTIONS) {
@@ -67,9 +69,7 @@ const AddFestival = () => {
         <Button
           variant="add"
           text={'추가하기'}
-          disabled={
-            selectedFestivals.length === 0 || TOTAL_SELECTIONS >= MAX_SELECTIONS
-          }
+          disabled={isButtonDisabled}
           onClick={handleAddClick}
         />
       </div>


### PR DESCRIPTION
## 📌 Summary

- #527 

## 📚 Tasks

- 페스티벌의 추가 갯수를 3개 -> 5개로 수정합니다.
- toast 이벤트 트리거가 기존에는 '추가하기' 버튼을 클릭했을 때 동작하였는데, 이 부분을 '페스티벌 카드의 클릭' 으로 변경합니다
- 버튼의 disabled 되는 조건이 하나 더 증가했어요 
```tsx
  const isButtonDisabled =
    selectedFestivals.length === 0 || TOTAL_SELECTIONS >= MAX_SELECTIONS;
```



## 👀 To Reviewer

초기에는 당연히 
```tsx
  const handleFestivalClick = (festivalId: number, isSelected: boolean) => {
    if (isSelected) {
      removeSelect(festivalId);
    } else {
      addSelect(festivalId);
    }
  };
```
 이 핸들러 함수에서 클릭 되어있는(isSelected) 한 카드의 갯수가 max 보다 크거나 같아면 showToast 를 호출하면 된다고 생각했어요. 근데 React의 상태 업데이트의 특징을 고려하지 못했어요 `selectedFestivals` 가 setState 직후에 즉시 반영되지 않기 때문에 해제 클릭 시에도 조건이 맞아 toast 가 잘못 실행되는 문제가 발생했어요.

이를 해결하기 위해 **상태 변경을 감지하는 useEffect** 로 toast 트리거를 이동했습니다.
 
 ```tsx
  useEffect(() => {
    if (TOTAL_SELECTIONS >= MAX_SELECTIONS) {
      showToast();
    }
  }, [selectedFestivals, TOTAL_SELECTIONS, showToast]);
```

이런 비슷한 경우에 useEffect 로 상태 기반 조건 처리를 하는 것이 권장된다고 해서 이 방법을 선택했는데 다른 더 좋은 방법이 있을까요?



