### PR TITLE
Feat(client): 추천 음악 정지 기능 추가 

### DIFF
--- a/apps/client/src/pages/home/components/suggest-music-section.tsx
+++ b/apps/client/src/pages/home/components/suggest-music-section.tsx
@@ -27,11 +27,12 @@ const SuggestMusicSection = ({
     isPending,
   } = useSuggestMusic(data.performanceId, musicIdList);
 
-  const { musicList, onClickPlayToggle, audioRef } = useMusicPlayer(
+  const { musicList, onClickPlayToggle, audioRef, audioStop } = useMusicPlayer(
     suggestMusic?.musics ?? [],
   );
 
   const handleRefreshMusic = () => {
+    audioStop();
     const ids = musicList.map((music) => music.musicId);
     setMusicIdList(ids);
     refetch();

--- a/apps/client/src/pages/home/components/suggest-music-section.tsx
+++ b/apps/client/src/pages/home/components/suggest-music-section.tsx
@@ -27,12 +27,12 @@ const SuggestMusicSection = ({
     isPending,
   } = useSuggestMusic(data.performanceId, musicIdList);
 
-  const { musicList, onClickPlayToggle, audioRef, audioStop } = useMusicPlayer(
+  const { musicList, onClickPlayToggle, audioRef, stopAudio } = useMusicPlayer(
     suggestMusic?.musics ?? [],
   );
 
   const handleRefreshMusic = () => {
-    audioStop();
+    stopAudio();
     const ids = musicList.map((music) => music.musicId);
     setMusicIdList(ids);
     refetch();

--- a/apps/client/src/shared/hooks/use-music-player.ts
+++ b/apps/client/src/shared/hooks/use-music-player.ts
@@ -6,6 +6,13 @@ export const useMusicPlayer = (data: musics[]) => {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const [currentPlayingId, setCurrentPlayingId] = useState<string | null>(null);
 
+  const audioStop = () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    audio.pause();
+    setCurrentPlayingId(null);
+  };
+
   const onClickPlayToggle = (musicId: string) => {
     const selectedMusic = data.find((music) => music.musicId === musicId);
     if (!selectedMusic || !selectedMusic.previewUrl || !audioRef.current)
@@ -14,8 +21,7 @@ export const useMusicPlayer = (data: musics[]) => {
     const audio = audioRef.current;
 
     if (currentPlayingId === musicId && !audio.paused) {
-      audio.pause();
-      setCurrentPlayingId(null);
+      audioStop();
       return;
     }
 
@@ -47,5 +53,6 @@ export const useMusicPlayer = (data: musics[]) => {
     musicList,
     audioRef,
     onClickPlayToggle,
+    audioStop,
   };
 };

--- a/apps/client/src/shared/hooks/use-music-player.ts
+++ b/apps/client/src/shared/hooks/use-music-player.ts
@@ -6,7 +6,7 @@ export const useMusicPlayer = (data: musics[]) => {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const [currentPlayingId, setCurrentPlayingId] = useState<string | null>(null);
 
-  const audioStop = () => {
+  const stopAudio = () => {
     const audio = audioRef.current;
     if (!audio) return;
     audio.pause();
@@ -21,7 +21,7 @@ export const useMusicPlayer = (data: musics[]) => {
     const audio = audioRef.current;
 
     if (currentPlayingId === musicId && !audio.paused) {
-      audioStop();
+      stopAudio();
       return;
     }
 
@@ -53,6 +53,6 @@ export const useMusicPlayer = (data: musics[]) => {
     musicList,
     audioRef,
     onClickPlayToggle,
-    audioStop,
+    stopAudio,
   };
 };


### PR DESCRIPTION
## 📌 Summary

- #536 

## 📚 Tasks

- 다른 노래 더보기 버튼 클릭 시 음악 재생 일시정지  

## 👀 To Reviewer

노래 재생 중 사용자가 다른 노래 더보기 버튼을 클릭하면 기존에는 노래가 계속 재생되었는데, 재생되지 않아야 더 자연스러운 경험이라고 생각해서 이 부분 수정했습니다 . 

기획파트랑 얘기 된 부분입니다. 
[슬랙 스레드](https://weareconfeti.slack.com/archives/C08JK2MUDV3/p1748360340414689)

audioRef 를 통해 직접 제어할 수도 있었지만, 재생 중지 로직의 명확한 책임 분리를 위해 별도의 audioStop 핸들러 함수를 정의했어요

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요. 필요시 .gif 형식으로 첨부해주세요.
-->
