### PR TITLE
Fix(client): 타임테이블 오류 해결

### DIFF
--- a/apps/client/src/pages/timetable/components/calender/calender.tsx
+++ b/apps/client/src/pages/timetable/components/calender/calender.tsx
@@ -1,7 +1,6 @@
 import {
   checkFestivalDateStatus,
   createFestivalDateMap,
-  useDayNumSelection,
   useFormattedWeek,
 } from '@pages/timetable/hooks/use-data-formatted';
 
@@ -13,19 +12,21 @@ import * as styles from './calender.css';
 interface CalenderProps {
   festivalDates: { festivalDateId: number; festivalAt: string }[];
   onDateSelect: (dateId: number) => void;
+  selectedDateId: number;
 }
 
-const Calender = ({ festivalDates, onDateSelect }: CalenderProps) => {
+const Calender = ({
+  festivalDates,
+  onDateSelect,
+  selectedDateId,
+}: CalenderProps) => {
   const firstDate = festivalDates?.[0]?.festivalAt || '';
   const { weekDays } = useFormattedWeek(firstDate);
   const festivalDateMap = createFestivalDateMap(festivalDates || []);
-  const { selectedDayNumId, handleDayNumClick } = useDayNumSelection(
-    festivalDates || [],
-  );
+
   const formattedYear = formatDate(firstDate, 'koHalf');
 
   const handleDateClick = (festivalDateId: number) => {
-    handleDayNumClick(festivalDateId);
     onDateSelect(festivalDateId);
   };
 
@@ -42,7 +43,7 @@ const Calender = ({ festivalDates, onDateSelect }: CalenderProps) => {
 
   const dateDetails = weekDays.map((day, id) => ({
     ...day,
-    ...checkFestivalDateStatus(festivalDateMap, id, selectedDayNumId),
+    ...checkFestivalDateStatus(festivalDateMap, id, selectedDateId),
   }));
 
   return (

--- a/apps/client/src/pages/timetable/components/festival-selector/festival-button.css.ts
+++ b/apps/client/src/pages/timetable/components/festival-selector/festival-button.css.ts
@@ -36,15 +36,13 @@ export const festivalButton = recipe({
         transition: 'background-image 0.4s ease, border-color 0.4s ease',
       },
     },
-    // isFestivalDeleteMode: {
-    //   true: {},
-    // },
   },
 });
 
 export const text = style({
   display: '-webkit-box',
   width: '7.4rem',
+  height: '3rem',
   WebkitBoxOrient: 'vertical',
   WebkitLineClamp: '2',
   overflow: 'hidden',

--- a/apps/client/src/pages/timetable/components/festival-selector/festival-button.tsx
+++ b/apps/client/src/pages/timetable/components/festival-selector/festival-button.tsx
@@ -26,7 +26,7 @@ const FestivalButton = ({
       <button className={styles.festivalButton({ isSelected })} {...props}>
         <img src={imgUrl} alt={title} />
       </button>
-      <span className={styles.text}>{title}</span>
+      <p className={styles.text}>{title}</p>
     </label>
   );
 };

--- a/apps/client/src/pages/timetable/components/timetable-board/booth-open-box.css.ts
+++ b/apps/client/src/pages/timetable/components/timetable-board/booth-open-box.css.ts
@@ -8,10 +8,10 @@ export const wrapper = style({
   position: 'absolute',
   top: '0',
   right: '0',
-  height: '4.5rem',
-  width: 'calc(100% - 2.9rem)',
+  height: '45px',
+  width: 'calc(100% - 29px)',
   color: themeVars.color.gray600,
   background: themeVars.color.gray200,
   zIndex: themeVars.zIndex.timeTable.row,
-  marginTop: '0.7rem',
+  marginTop: '7px',
 });

--- a/apps/client/src/pages/timetable/components/timetable-board/time-cell.css.ts
+++ b/apps/client/src/pages/timetable/components/timetable-board/time-cell.css.ts
@@ -7,6 +7,7 @@ export const timeList = style({
   display: 'flex',
   alignItems: 'center',
   paddingBottom: '31px',
+  width: '100%',
   zIndex: themeVars.zIndex.timeTable.row,
 });
 
@@ -14,7 +15,8 @@ export const timeP = recipe({
   base: {
     ...themeVars.fontStyles.body5_r_12,
     padding: '0 4px',
-    marginRight: '8px',
+    width: '23px',
+    marginRight: '7px',
     backgroundColor: themeVars.color.white,
   },
   variants: {
@@ -35,7 +37,7 @@ export const timeP = recipe({
 export const timeBar = recipe({
   base: {
     height: '1px',
-    width: 'calc(100%)',
+    width: 'calc(100% - 29px)',
     margin: '0',
     color: themeVars.color.gray300,
     zIndex: themeVars.zIndex.timeTable.row,

--- a/apps/client/src/pages/timetable/components/timetable-board/time-cell.css.ts
+++ b/apps/client/src/pages/timetable/components/timetable-board/time-cell.css.ts
@@ -15,7 +15,7 @@ export const timeP = recipe({
   base: {
     ...themeVars.fontStyles.body5_r_12,
     padding: '0 4px',
-    width: '23px',
+    width: '22px',
     marginRight: '7px',
     backgroundColor: themeVars.color.white,
   },

--- a/apps/client/src/pages/timetable/components/timetable-board/time-cell.css.ts
+++ b/apps/client/src/pages/timetable/components/timetable-board/time-cell.css.ts
@@ -6,15 +6,15 @@ import { themeVars } from '@confeti/design-system/styles';
 export const timeList = style({
   display: 'flex',
   alignItems: 'center',
-  paddingBottom: '3rem',
+  paddingBottom: '31px',
   zIndex: themeVars.zIndex.timeTable.row,
 });
 
 export const timeP = recipe({
   base: {
     ...themeVars.fontStyles.body5_r_12,
-    padding: '0 0.4rem',
-    marginRight: '1.1rem',
+    padding: '0 4px',
+    marginRight: '7px',
     backgroundColor: themeVars.color.white,
   },
   variants: {
@@ -34,8 +34,9 @@ export const timeP = recipe({
 
 export const timeBar = recipe({
   base: {
-    height: '0.1rem',
-    width: 'calc(100% - 3rem)',
+    height: '1px',
+    width: 'calc(100% - 30px)',
+    margin: '0',
     color: themeVars.color.gray300,
     zIndex: themeVars.zIndex.timeTable.row,
   },

--- a/apps/client/src/pages/timetable/components/timetable-board/time-cell.css.ts
+++ b/apps/client/src/pages/timetable/components/timetable-board/time-cell.css.ts
@@ -14,7 +14,7 @@ export const timeP = recipe({
   base: {
     ...themeVars.fontStyles.body5_r_12,
     padding: '0 4px',
-    marginRight: '7px',
+    marginRight: '8px',
     backgroundColor: themeVars.color.white,
   },
   variants: {
@@ -35,7 +35,7 @@ export const timeP = recipe({
 export const timeBar = recipe({
   base: {
     height: '1px',
-    width: 'calc(100% - 30px)',
+    width: 'calc(100%)',
     margin: '0',
     color: themeVars.color.gray300,
     zIndex: themeVars.zIndex.timeTable.row,

--- a/apps/client/src/pages/timetable/components/timetable-board/timetable-board.css.ts
+++ b/apps/client/src/pages/timetable/components/timetable-board/timetable-board.css.ts
@@ -5,8 +5,8 @@ import { themeVars } from '@confeti/design-system/styles';
 
 export const container = style({
   backgroundColor: themeVars.color.white,
-  padding: '0rem 2rem 2rem 2rem',
-  maxWidth: '47.7rem',
+  padding: '0 20px 20px 20px',
+  maxWidth: '477px',
   width: '100%',
   overflowX: 'auto',
   position: 'relative',
@@ -15,7 +15,7 @@ export const container = style({
   },
   msOverflowStyle: 'none',
   scrollbarWidth: 'none',
-  paddingTop: '1.2rem',
+  paddingTop: '12px',
   overflowY: 'visible',
   marginBottom: '9rem',
 });
@@ -28,8 +28,8 @@ export const wrapper = recipe({
   variants: {
     stageCount: {
       4: {
-        width: '43.7rem',
-        minWidth: '43.7rem',
+        width: '437px',
+        minWidth: '437px',
       },
     },
   },
@@ -37,9 +37,9 @@ export const wrapper = recipe({
 
 export const stagesContainer = style({
   display: 'flex',
-  width: 'calc(100% - 2.9rem)',
+  width: 'calc(100% - 29px)',
   position: 'absolute',
-  left: '2.9rem',
+  left: '29px',
   top: 0,
   bottom: 0,
   backgroundColor: themeVars.color.white,
@@ -47,26 +47,26 @@ export const stagesContainer = style({
 
 export const timeList = style({
   ...themeVars.display.flexAlignCenter,
-  marginBottom: '2.2rem',
+  marginBottom: '22px',
   backgroundColor: themeVars.color.white,
 });
 
 export const minutesP = style({
   ...themeVars.fontStyles.body5_r_12,
-  padding: '0 0.4rem',
-  marginRight: '0.7rem',
+  padding: '0 4px',
+  marginRight: '7px',
   color: themeVars.color.gray400,
 });
 
 export const timeP = style({
   ...themeVars.fontStyles.body5_r_12,
-  padding: '0 0.4rem',
-  marginRight: '0.7rem',
+  padding: '0 4px',
+  marginRight: '7px',
   color: themeVars.color.gray600,
 });
 
 export const timeBar = style({
-  height: '0.1rem',
+  height: '1px',
   width: '100%',
   color: themeVars.color.gray300,
   zIndex: themeVars.zIndex.timeTable.row,
@@ -77,12 +77,12 @@ export const saveButton = style({
 });
 
 export const saveButtonWrapper = style({
-  paddingTop: '3.2rem',
+  paddingTop: '32px',
 });
 
 export const stageColumn = style({
   flex: 1,
-  minWidth: '10.2rem',
+  minWidth: '102px',
   position: 'relative',
 });
 

--- a/apps/client/src/pages/timetable/components/timetable-board/timetable-item.css.ts
+++ b/apps/client/src/pages/timetable/components/timetable-board/timetable-item.css.ts
@@ -20,10 +20,10 @@ export const itemsWrapper = recipe({
     zIndex: themeVars.zIndex.timeTable.content,
     cursor: 'pointer',
     transition: 'background-color 0.18s ease-out',
-    minWidth: '10.3rem',
+    minWidth: '103px',
     boxSizing: 'border-box',
     margin: 0,
-    padding: '0.5rem',
+    padding: '5px',
   },
   variants: {
     isSelected: {
@@ -54,7 +54,7 @@ export const artistName = recipe({
     whiteSpace: 'nowrap',
     backgroundColor: 'inherit',
     boxSizing: 'border-box',
-    padding: '0 0.2rem',
+    padding: '0 2px',
   },
   variants: {
     isSelected: {

--- a/apps/client/src/pages/timetable/components/timetable-board/timetable-item.tsx
+++ b/apps/client/src/pages/timetable/components/timetable-board/timetable-item.tsx
@@ -64,8 +64,8 @@ const TimetableItem = ({
   };
 
   const MARGIN_TOP_PX = 7;
-  const top = `${Math.round(minutesFromOpen * TIME_SLOT_HEIGHT_1_MIN + MARGIN_TOP_PX)}px`;
-  const height = `${Math.round(totalPerformMin * TIME_SLOT_HEIGHT_1_MIN)}px`;
+  const top = `${minutesFromOpen * TIME_SLOT_HEIGHT_1_MIN + MARGIN_TOP_PX}px`;
+  const height = `${totalPerformMin * TIME_SLOT_HEIGHT_1_MIN}px`;
 
   const dynamicVars = assignInlineVars({
     [styles.top]: top,

--- a/apps/client/src/pages/timetable/components/timetable-board/timetable-item.tsx
+++ b/apps/client/src/pages/timetable/components/timetable-board/timetable-item.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
+import { TIME_SLOT_HEIGHT_1_MIN } from '@pages/timetable/constants';
 import {
   calcMinutesFromOpen,
-  calcTotalFestivalMinutes,
   calcTotalMinutes,
   parseTimeString,
 } from '@pages/timetable/utils';
@@ -56,8 +56,6 @@ const TimetableItem = ({
     openMin,
   );
 
-  const totalFestivalMinutes = calcTotalFestivalMinutes(openHour, openMin);
-
   const handleSetSelectedBlock = () => {
     if (isEditTimetableMode) {
       setSelectBlock((prev) => !prev);
@@ -65,8 +63,9 @@ const TimetableItem = ({
     onClick(userTimetableId, !selectBlock);
   };
 
-  const top = `calc(${(minutesFromOpen / totalFestivalMinutes) * 98.6}% + 0.7rem)`;
-  const height = `calc((${totalPerformMin} / ${totalFestivalMinutes}) * 100%)`;
+  const MARGIN_TOP_PX = 7;
+  const top = `${Math.round(minutesFromOpen * TIME_SLOT_HEIGHT_1_MIN + MARGIN_TOP_PX)}px`;
+  const height = `${Math.round(totalPerformMin * TIME_SLOT_HEIGHT_1_MIN)}px`;
 
   const dynamicVars = assignInlineVars({
     [styles.top]: top,

--- a/apps/client/src/pages/timetable/constants/index.ts
+++ b/apps/client/src/pages/timetable/constants/index.ts
@@ -1,5 +1,5 @@
 export const HALF_HOUR_TO_MINUTES = 30;
-export const TIME_SLOT_HEIGHT_5_MIN = 0.75;
+export const TIME_SLOT_HEIGHT_1_MIN = 1.5;
 export const ONE_HOUR_TO_MINUTES = 60;
 export const END_HOUR = 24;
 export const MAX_SELECTIONS = 5;

--- a/apps/client/src/pages/timetable/hooks/use-data-formatted.ts
+++ b/apps/client/src/pages/timetable/hooks/use-data-formatted.ts
@@ -32,28 +32,6 @@ export const useFormattedWeek = (date: string | null) => {
   }, [date]);
 };
 
-export const useDayNumSelection = (
-  festivalDates: { festivalDateId: number; festivalAt: string }[],
-) => {
-  const [selectedDayNumId, setSelectedDateId] = useState<number | null>(null);
-
-  useEffect(() => {
-    if (festivalDates && festivalDates.length > 0) {
-      setSelectedDateId(festivalDates[0].festivalDateId);
-    }
-  }, [festivalDates]);
-
-  const handleDayNumClick = (festivalDateId: number) => {
-    setSelectedDateId(festivalDateId);
-  };
-
-  return {
-    selectedDayNumId,
-    handleDayNumClick,
-    setSelectedDateId,
-  };
-};
-
 // festivalDateMap 생성 함수
 export const createFestivalDateMap = (
   festivalDates: { festivalDateId: number }[],

--- a/apps/client/src/pages/timetable/hooks/use-data-formatted.ts
+++ b/apps/client/src/pages/timetable/hooks/use-data-formatted.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 import { WEEKDAYS } from '@shared/constants/day';
 

--- a/apps/client/src/pages/timetable/page/timetable-content/timetable-content.tsx
+++ b/apps/client/src/pages/timetable/page/timetable-content/timetable-content.tsx
@@ -34,7 +34,7 @@ const TimetableContent = ({ festivals }: TimetableContentProps) => {
     enabled: selectedDateId !== undefined,
   });
 
-  if (!boardData) return null;
+  if (!boardData || !selectedDateId) return null;
 
   return (
     <div className={styles.wrapper}>
@@ -46,6 +46,7 @@ const TimetableContent = ({ festivals }: TimetableContentProps) => {
       <Calender
         festivalDates={selectedFestivalInfo.festivalDates}
         onDateSelect={handleSelectDate}
+        selectedDateId={selectedDateId}
       />
       <div className={styles.timeTableWrapper} ref={elementRef}>
         <FestivalStage timetableInfo={boardData} />

--- a/apps/client/src/pages/timetable/page/timetable-content/timetable-content.tsx
+++ b/apps/client/src/pages/timetable/page/timetable-content/timetable-content.tsx
@@ -6,26 +6,32 @@ import TimeTableBoard from '@pages/timetable/components/timetable-board/timetabl
 import { useFestivalSelect } from '@pages/timetable/hooks/use-festival-select';
 import { useImageDownload } from '@pages/timetable/hooks/use-image-download';
 import { useTimetableEdit } from '@pages/timetable/hooks/use-timetable-edit';
+import { useQuery } from '@tanstack/react-query';
 
-import {
-  FestivalTimetable,
-  FestivalTimetableExtended,
-} from '@shared/types/festival-timetable-response';
+import { FESTIVAL_TIMETABLE_QUERY_OPTIONS } from '@shared/apis/timetable/festival-timetable-queries';
+import { FestivalTimetable } from '@shared/types/festival-timetable-response';
 
 import * as styles from './timetable-content.css';
 
 interface TimetableContentProps {
   festivals: FestivalTimetable[];
-  boardData?: FestivalTimetableExtended;
 }
 
-const TimetableContent = ({ festivals, boardData }: TimetableContentProps) => {
-  const { selectedFestivalInfo, handleSelectFestival, handleSelectDate } =
-    useFestivalSelect(festivals);
+const TimetableContent = ({ festivals }: TimetableContentProps) => {
+  const {
+    selectedFestivalInfo,
+    selectedDateId,
+    handleSelectFestival,
+    handleSelectDate,
+  } = useFestivalSelect(festivals);
   const { isEditTimetableMode, toggleEditTimetableMode } = useTimetableEdit();
 
   const { elementRef, downloadImage } = useImageDownload<HTMLDivElement>({
     fileName: `${selectedFestivalInfo.title}`,
+  });
+  const { data: boardData } = useQuery({
+    ...FESTIVAL_TIMETABLE_QUERY_OPTIONS.FESTIVAL_TIMETABLE(selectedDateId ?? 0),
+    enabled: selectedDateId !== undefined,
   });
 
   if (!boardData) return null;

--- a/apps/client/src/pages/timetable/page/timetable-page.tsx
+++ b/apps/client/src/pages/timetable/page/timetable-page.tsx
@@ -1,8 +1,7 @@
 import { useMemo } from 'react';
-import { useFestivalSelect } from '@pages/timetable/hooks/use-festival-select';
 import EmptyFestivalSection from '@pages/timetable/page/empty/empty-festival-section';
 import TimetableContent from '@pages/timetable/page/timetable-content/timetable-content';
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { FESTIVAL_TIMETABLE_QUERY_OPTIONS } from '@shared/apis/timetable/festival-timetable-queries';
 import { SwitchCase } from '@shared/components/switch-case';
@@ -16,22 +15,13 @@ const TimeTablePage = () => {
   const { data: timeTableHistory } = useSuspenseQuery(
     FESTIVAL_TIMETABLE_QUERY_OPTIONS.ONBOARDING(),
   );
-  const { selectedDateId } = useFestivalSelect(festivalsData.festivals);
-  const { data: boardData } = useQuery({
-    ...FESTIVAL_TIMETABLE_QUERY_OPTIONS.FESTIVAL_TIMETABLE(selectedDateId ?? 0),
-    enabled: selectedDateId !== undefined,
-  });
 
   const timetableState = useMemo<'onboard' | 'empty' | 'render'>(() => {
     if (!timeTableHistory.hasTimetableHistory) return 'onboard';
     if (festivalsData.festivals.length === 0) return 'empty';
-    if (festivalsData.festivals.length > 0 && boardData) return 'render';
+    if (festivalsData.festivals.length > 0) return 'render';
     return 'empty';
-  }, [
-    timeTableHistory.hasTimetableHistory,
-    festivalsData.festivals,
-    boardData,
-  ]);
+  }, [timeTableHistory.hasTimetableHistory, festivalsData.festivals]);
 
   return (
     <SwitchCase
@@ -39,12 +29,7 @@ const TimeTablePage = () => {
       caseBy={{
         onboard: () => <TimetableOnboard />,
         empty: () => <EmptyFestivalSection />,
-        render: () => (
-          <TimetableContent
-            festivals={festivalsData.festivals}
-            boardData={boardData}
-          />
-        ),
+        render: () => <TimetableContent festivals={festivalsData.festivals} />,
       }}
     />
   );

--- a/apps/client/src/pages/timetable/utils/index.ts
+++ b/apps/client/src/pages/timetable/utils/index.ts
@@ -1,7 +1,4 @@
-import {
-  ONE_HOUR_TO_MINUTES,
-  TIME_SLOT_HEIGHT_5_MIN,
-} from '@pages/timetable/constants';
+import { ONE_HOUR_TO_MINUTES } from '@pages/timetable/constants';
 
 export const generateTableRow = (startTime: string) => {
   const startHour = Number(startTime);
@@ -15,13 +12,6 @@ export const parseTimeString = (timeString: string): string[] => {
 
   const [hour, min] = time.split(':');
   return [hour, min];
-};
-
-// TODO: 추후 수정 필요, 사용 안되고 있음
-export const calcPosition = (totalMin: number, minutesFromOpen: number) => {
-  const top = (minutesFromOpen / 5) * TIME_SLOT_HEIGHT_5_MIN;
-  const diff = (totalMin / 5) * TIME_SLOT_HEIGHT_5_MIN;
-  return { top, diff };
 };
 
 export const calcTotalMinutes = (
@@ -57,17 +47,4 @@ export const calcMinutesFromOpen = (
   const openTotalMin = openHourNum * ONE_HOUR_TO_MINUTES + openMinNum;
 
   return startTotalMin - openTotalMin;
-};
-
-export const calcTotalFestivalMinutes = (
-  startHour: string,
-  startMin: string,
-) => {
-  const startHourNum = Number(startHour);
-  const startMinNum = Number(startMin);
-
-  const hoursUntilEnd = 24 - startHourNum;
-  const totalFestivalMinutes = hoursUntilEnd * 60 - startMinNum;
-
-  return totalFestivalMinutes;
 };


### PR DESCRIPTION
## 📌 Summary

> - #560 


## 📚 Tasks

- timetableBoard layout 픽셀 단위 모두 rem -> px로 변경
- 날짜 선택 변경에 따라 알맞은 타임테이블 렌더링하도록 수정

## 👀 To Reviewer
- 정말 한치 오차도 없이 정확하게 하려면 px로 변경하는 수밖에 없었어요 rem으로 하면 저번에 qa 잡힌 것처럼 조금씩 오차가 생기더라구요. 
- px로 변경하면서, 1분당 1.5px로 계산하고 있어 미세한 단위라 그런지 확대/축소 시 위치가 조금씩 어긋나고 있어요...
  일단 화면 100% 비율일때를 기준으로 정확하게 맞춘거라... 이부분 어떻게 해야할 지 아직 고민중입니다. (곡추가 검색 해결하고 다시 살펴볼게요)
- 날짜 변경 시 타임테이블 알맞게 렌더링되도록 수정했습니다!

이전 pr 리베이스 해줬더니 변경사항이 너무 많이 잡혀서 새로 올립니다ㅜㅜ


## 📸 Screenshot

- 무대 2개일 때
<img width="429" alt="스크린샷 2025-06-10 오후 10 56 03" src="https://github.com/user-attachments/assets/4b589e0a-4329-44df-a410-c4c33bff4fa7" />

- 무대 3개일 때
<img width="431" alt="스크린샷 2025-06-10 오후 10 50 54" src="https://github.com/user-attachments/assets/f8934723-1bc8-447e-9e90-212244f37c7d" />

- 무대 4개일 때
<img width="430" alt="스크린샷 2025-06-10 오후 10 55 14" src="https://github.com/user-attachments/assets/2ff041d1-9de5-45fd-93f6-9bf20468b4f0" />
