### PR TITLE
Feat(admin): API 기본 설정 및 스키마 수정

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@confeti/design-system": "workspace:*",
     "@hookform/resolvers": "^5.1.1",
+    "@tanstack/react-query": "^5.62.16",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.2",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -16,6 +16,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.2",
+    "axios": "^1.7.9",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.57.0",

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -1,13 +1,26 @@
 import { RouterProvider } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { ThemeProvider } from '@confeti/design-system';
 import router from '@shared/router/router';
 
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      refetchOnWindowFocus: false,
+      throwOnError: true,
+    },
+  },
+});
+
 function App() {
   return (
-    <ThemeProvider>
-      <RouterProvider router={router} />
-    </ThemeProvider>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider>
+        <RouterProvider router={router} />
+      </ThemeProvider>
+    </QueryClientProvider>
   );
 }
 

--- a/apps/admin/src/pages/dashboard/components/edit-festival-form.tsx
+++ b/apps/admin/src/pages/dashboard/components/edit-festival-form.tsx
@@ -27,6 +27,10 @@ const EditFestivalForm = ({ id }: Props) => {
     useImagePreview();
   const { preview: logoPreview, handleFileChange: handleLogoChange } =
     useImagePreview();
+  const {
+    preview: reservationLogoPreview,
+    handleFileChange: handleReservationLogoChange,
+  } = useImagePreview();
 
   const {
     register,
@@ -82,6 +86,8 @@ const EditFestivalForm = ({ id }: Props) => {
             register={register}
             errors={errors}
             control={control}
+            reservationLogoPreview={reservationLogoPreview}
+            onReservationLogoChange={handleReservationLogoChange}
           />
         </>
       )}

--- a/apps/admin/src/pages/dashboard/components/edit-festival-form.tsx
+++ b/apps/admin/src/pages/dashboard/components/edit-festival-form.tsx
@@ -8,6 +8,7 @@ import {
   FestivalStageFormField,
 } from '@shared/components/form/festival-form-fields';
 import { FESTIVAL_TAB } from '@shared/constants/tab';
+import { useImagePreview } from '@shared/hooks/use-image-preview';
 import { useZodForm } from '@shared/hooks/use-zod-form';
 import {
   festivalDefaultValues,
@@ -22,6 +23,10 @@ interface Props {
 
 const EditFestivalForm = ({ id }: Props) => {
   const [tab, setTab] = useState<FESTIVAL_TAB>(FESTIVAL_TAB.BASIC);
+  const { preview: posterPreview, handleFileChange: handlePosterChange } =
+    useImagePreview();
+  const { preview: logoPreview, handleFileChange: handleLogoChange } =
+    useImagePreview();
 
   const {
     register,
@@ -63,6 +68,10 @@ const EditFestivalForm = ({ id }: Props) => {
             register={register}
             errors={errors}
             control={control}
+            posterPreview={posterPreview}
+            logoPreview={logoPreview}
+            onPosterChange={handlePosterChange}
+            onLogoChange={handleLogoChange}
           />
           <FestivalStageFormField
             register={register}

--- a/apps/admin/src/pages/festival/components/festival-form.tsx
+++ b/apps/admin/src/pages/festival/components/festival-form.tsx
@@ -23,6 +23,10 @@ const FestivalForm = () => {
     useImagePreview();
   const { preview: logoPreview, handleFileChange: handleLogoChange } =
     useImagePreview();
+  const {
+    preview: reservationLogoPreview,
+    handleFileChange: handleReservationLogoChange,
+  } = useImagePreview();
 
   const {
     register,
@@ -78,6 +82,8 @@ const FestivalForm = () => {
             register={register}
             errors={errors}
             control={control}
+            reservationLogoPreview={reservationLogoPreview}
+            onReservationLogoChange={handleReservationLogoChange}
           />
         </>
       )}

--- a/apps/admin/src/pages/festival/components/festival-form.tsx
+++ b/apps/admin/src/pages/festival/components/festival-form.tsx
@@ -8,6 +8,7 @@ import {
   FestivalStageFormField,
 } from '@shared/components/form/festival-form-fields';
 import { FESTIVAL_TAB } from '@shared/constants/tab';
+import { useImagePreview } from '@shared/hooks/use-image-preview';
 import { useZodForm } from '@shared/hooks/use-zod-form';
 import {
   festivalDefaultValues,
@@ -18,6 +19,10 @@ import * as styles from './festival-form.css';
 
 const FestivalForm = () => {
   const [tab, setTab] = useState<FESTIVAL_TAB>(FESTIVAL_TAB.BASIC);
+  const { preview: posterPreview, handleFileChange: handlePosterChange } =
+    useImagePreview();
+  const { preview: logoPreview, handleFileChange: handleLogoChange } =
+    useImagePreview();
 
   const {
     register,
@@ -59,6 +64,10 @@ const FestivalForm = () => {
             register={register}
             errors={errors}
             control={control}
+            posterPreview={posterPreview}
+            logoPreview={logoPreview}
+            onPosterChange={handlePosterChange}
+            onLogoChange={handleLogoChange}
           />
           <FestivalStageFormField
             register={register}
@@ -82,7 +91,7 @@ const FestivalForm = () => {
       )}
 
       <button type="submit" className={styles.submitButton}>
-        저장하기
+        등록하기
       </button>
     </form>
   );

--- a/apps/admin/src/shared/apis/concert-queries.ts
+++ b/apps/admin/src/shared/apis/concert-queries.ts
@@ -43,23 +43,7 @@ export const getConcertList = async (): Promise<ConcertListItem[]> => {
 };
 
 export const postConcert = async (concert: Concert): Promise<Concert> => {
-  const formData = new FormData();
-  const dto = toConcertCreateDTO(concert);
-
-  formData.append('posterImg', dto.posterImg);
-  dto.reservationUrls.forEach((url, index) => {
-    formData.append(`reservationUrls[${index}].logoImg`, url.logoImg);
-  });
-
-  const jsonData = {
-    ...dto,
-    posterImg: undefined,
-    reservationUrls: dto.reservationUrls.map((url) => ({
-      ...url,
-      logoImg: undefined,
-    })),
-  };
-  formData.append('data', JSON.stringify(jsonData));
+  const formData = createFormData(concert);
 
   const response = await post<BaseResponse<ConcertDetailDTO>>(
     END_POINT.CONCERT,
@@ -77,6 +61,21 @@ export const patchConcert = async (
   concertId: number,
   concert: Concert,
 ): Promise<Concert> => {
+  const formData = createFormData(concert);
+
+  const response = await patch<BaseResponse<ConcertDetailDTO>>(
+    END_POINT.CONCERT_DETAIL(concertId),
+    formData,
+    {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    },
+  );
+  return toConcert(response.data);
+};
+
+const createFormData = (concert: Concert): FormData => {
   const formData = new FormData();
   const dto = toConcertCreateDTO(concert);
 
@@ -95,14 +94,5 @@ export const patchConcert = async (
   };
   formData.append('data', JSON.stringify(jsonData));
 
-  const response = await patch<BaseResponse<ConcertDetailDTO>>(
-    END_POINT.CONCERT_DETAIL(concertId),
-    formData,
-    {
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
-    },
-  );
-  return toConcert(response.data);
+  return formData;
 };

--- a/apps/admin/src/shared/apis/concert-queries.ts
+++ b/apps/admin/src/shared/apis/concert-queries.ts
@@ -1,0 +1,108 @@
+import { queryOptions } from '@tanstack/react-query';
+
+import { get, patch, post } from '@shared/apis/config/instance';
+import { END_POINT } from '@shared/constants/api';
+import { CONCERT_QUERY_KEY } from '@shared/constants/query-key';
+import {
+  Concert,
+  ConcertListItem,
+  toConcert,
+  toConcertCreateDTO,
+  toConcertListItem,
+} from '@shared/models/concert';
+import {
+  BaseResponse,
+  ConcertDetailDTO,
+  ConcertListDTO,
+} from '@shared/types/api';
+
+export const CONCERT_QUERY_OPTIONS = {
+  ALL: () => queryOptions({ queryKey: CONCERT_QUERY_KEY.ALL }),
+  CONCERT: (concertId: number) =>
+    queryOptions({
+      queryKey: CONCERT_QUERY_KEY.CONCERT(concertId),
+      queryFn: () => getConcert(concertId),
+    }),
+  CONCERT_LIST: () =>
+    queryOptions({
+      queryKey: CONCERT_QUERY_KEY.ALL,
+      queryFn: getConcertList,
+    }),
+};
+
+export const getConcert = async (concertId: number): Promise<Concert> => {
+  const response = await get<BaseResponse<ConcertDetailDTO>>(
+    END_POINT.CONCERT_DETAIL(concertId),
+  );
+  return toConcert(response.data);
+};
+
+export const getConcertList = async (): Promise<ConcertListItem[]> => {
+  const response = await get<BaseResponse<ConcertListDTO>>(END_POINT.CONCERT);
+  return response.data.concerts.map(toConcertListItem);
+};
+
+export const postConcert = async (concert: Concert): Promise<Concert> => {
+  const formData = new FormData();
+  const dto = toConcertCreateDTO(concert);
+
+  formData.append('posterImg', dto.posterImg);
+  dto.reservationUrls.forEach((url, index) => {
+    formData.append(`reservationUrls[${index}].logoImg`, url.logoImg);
+  });
+
+  const jsonData = {
+    ...dto,
+    posterImg: undefined,
+    reservationUrls: dto.reservationUrls.map((url) => ({
+      ...url,
+      logoImg: undefined,
+    })),
+  };
+  formData.append('data', JSON.stringify(jsonData));
+
+  const response = await post<BaseResponse<ConcertDetailDTO>>(
+    END_POINT.CONCERT,
+    formData,
+    {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    },
+  );
+  return toConcert(response.data);
+};
+
+export const patchConcert = async (
+  concertId: number,
+  concert: Concert,
+): Promise<Concert> => {
+  const formData = new FormData();
+  const dto = toConcertCreateDTO(concert);
+
+  formData.append('posterImg', dto.posterImg);
+  dto.reservationUrls.forEach((url, index) => {
+    formData.append(`reservationUrls[${index}].logoImg`, url.logoImg);
+  });
+
+  const jsonData = {
+    ...dto,
+    posterImg: undefined,
+    reservationUrls: dto.reservationUrls.map((url) => ({
+      ...url,
+      logoImg: undefined,
+    })),
+  };
+  formData.append('data', JSON.stringify(jsonData));
+
+  const response = await patch<BaseResponse<ConcertDetailDTO>>(
+    END_POINT.CONCERT_DETAIL(concertId),
+    formData,
+    {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    },
+  );
+  return toConcert(response.data);
+};

--- a/apps/admin/src/shared/apis/concert-queries.ts
+++ b/apps/admin/src/shared/apis/concert-queries.ts
@@ -7,7 +7,6 @@ import {
   Concert,
   ConcertListItem,
   toConcert,
-  toConcertCreateDTO,
   toConcertListItem,
 } from '@shared/models/concert';
 import {
@@ -15,6 +14,7 @@ import {
   ConcertDetailDTO,
   ConcertListDTO,
 } from '@shared/types/api';
+import { createConcertFormData } from '@shared/utils/form-data';
 
 export const CONCERT_QUERY_OPTIONS = {
   ALL: () => queryOptions({ queryKey: CONCERT_QUERY_KEY.ALL }),
@@ -43,7 +43,7 @@ export const getConcertList = async (): Promise<ConcertListItem[]> => {
 };
 
 export const postConcert = async (concert: Concert): Promise<Concert> => {
-  const formData = createFormData(concert);
+  const formData = createConcertFormData(concert);
 
   const response = await post<BaseResponse<ConcertDetailDTO>>(
     END_POINT.CONCERT,
@@ -61,7 +61,7 @@ export const patchConcert = async (
   concertId: number,
   concert: Concert,
 ): Promise<Concert> => {
-  const formData = createFormData(concert);
+  const formData = createConcertFormData(concert);
 
   const response = await patch<BaseResponse<ConcertDetailDTO>>(
     END_POINT.CONCERT_DETAIL(concertId),
@@ -73,26 +73,4 @@ export const patchConcert = async (
     },
   );
   return toConcert(response.data);
-};
-
-const createFormData = (concert: Concert): FormData => {
-  const formData = new FormData();
-  const dto = toConcertCreateDTO(concert);
-
-  formData.append('posterImg', dto.posterImg);
-  dto.reservationUrls.forEach((url, index) => {
-    formData.append(`reservationUrls[${index}].logoImg`, url.logoImg);
-  });
-
-  const jsonData = {
-    ...dto,
-    posterImg: undefined,
-    reservationUrls: dto.reservationUrls.map((url) => ({
-      ...url,
-      logoImg: undefined,
-    })),
-  };
-  formData.append('data', JSON.stringify(jsonData));
-
-  return formData;
 };

--- a/apps/admin/src/shared/apis/config/instance.ts
+++ b/apps/admin/src/shared/apis/config/instance.ts
@@ -1,0 +1,31 @@
+import axios from 'axios';
+
+import { ENV_CONFIG } from '@shared/constants/config';
+
+export const axiosInstance = axios.create({
+  baseURL: ENV_CONFIG.ADMIN_BASE_URL,
+  withCredentials: true,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+export function get<T>(...args: Parameters<typeof axiosInstance.get>) {
+  return axiosInstance.get<T>(...args).then((res) => res.data);
+}
+
+export function post<T>(...args: Parameters<typeof axiosInstance.post>) {
+  return axiosInstance.post<T>(...args).then((res) => res.data);
+}
+
+export function put<T>(...args: Parameters<typeof axiosInstance.put>) {
+  return axiosInstance.put<T>(...args).then((res) => res.data);
+}
+
+export function patch<T>(...args: Parameters<typeof axiosInstance.patch>) {
+  return axiosInstance.patch<T>(...args).then((res) => res.data);
+}
+
+export function del<T>(...args: Parameters<typeof axiosInstance.delete>) {
+  return axiosInstance.delete<T>(...args).then((res) => res.data);
+}

--- a/apps/admin/src/shared/apis/festival-queries.ts
+++ b/apps/admin/src/shared/apis/festival-queries.ts
@@ -1,0 +1,93 @@
+import { queryOptions } from '@tanstack/react-query';
+
+import { get, patch, post } from '@shared/apis/config/instance';
+import { END_POINT } from '@shared/constants/api';
+import { FESTIVAL_QUERY_KEY } from '@shared/constants/query-key';
+import {
+  Festival,
+  FestivalListItem,
+  toFestival,
+  toFestivalListItem,
+} from '@shared/models/festival';
+import {
+  BaseResponse,
+  FestivalCreateDTO,
+  FestivalDetailDTO,
+  FestivalListDTO,
+  FestivalUpdateDTO,
+} from '@shared/types/api';
+
+export const FESTIVAL_QUERY_OPTIONS = {
+  ALL: () => queryOptions({ queryKey: FESTIVAL_QUERY_KEY.ALL }),
+  FESTIVAL: (festivalId: number) =>
+    queryOptions({
+      queryKey: FESTIVAL_QUERY_KEY.FESTIVAL(festivalId),
+      queryFn: () => getFestival(festivalId),
+    }),
+  FESTIVAL_LIST: () =>
+    queryOptions({
+      queryKey: FESTIVAL_QUERY_KEY.ALL,
+      queryFn: getFestivalList,
+    }),
+};
+
+export const getFestival = async (festivalId: number): Promise<Festival> => {
+  const response = await get<BaseResponse<FestivalDetailDTO>>(
+    END_POINT.FESTIVAL_DETAIL(festivalId),
+  );
+
+  return toFestival(response.data);
+};
+
+export const getFestivalList = async (): Promise<FestivalListItem[]> => {
+  const response = await get<BaseResponse<FestivalListDTO>>(END_POINT.FESTIVAL);
+  return response.data.festivals.map(toFestivalListItem);
+};
+
+const createFormData = (
+  festival: FestivalCreateDTO | FestivalUpdateDTO,
+): FormData => {
+  const formData = new FormData();
+
+  if (festival.posterImg) {
+    formData.append('posterImg', festival.posterImg);
+  }
+  if (festival.logoImg) {
+    formData.append('logoImg', festival.logoImg);
+  }
+  if (festival.reservationUrls) {
+    festival.reservationUrls.forEach((url, index) => {
+      if (url.logoImg) {
+        formData.append(`reservationUrls[${index}].logoImg`, url.logoImg);
+      }
+    });
+  }
+
+  const jsonData = {
+    ...festival,
+    posterImg: undefined,
+    logoImg: undefined,
+    reservationUrls: festival.reservationUrls?.map((url) => ({
+      ...url,
+      logoImg: undefined,
+    })),
+  };
+  formData.append('data', JSON.stringify(jsonData));
+
+  return formData;
+};
+
+export const postFestival = async (
+  festival: FestivalCreateDTO,
+): Promise<void> => {
+  const formData = createFormData(festival);
+  await post(END_POINT.FESTIVAL, formData);
+};
+
+export const patchFestival = async (
+  festivalId: number,
+  festival: FestivalUpdateDTO,
+): Promise<void> => {
+  const formData = createFormData(festival);
+  await patch(END_POINT.FESTIVAL_DETAIL(festivalId), formData);
+};

--- a/apps/admin/src/shared/apis/festival-queries.ts
+++ b/apps/admin/src/shared/apis/festival-queries.ts
@@ -16,6 +16,7 @@ import {
   FestivalListDTO,
   FestivalUpdateDTO,
 } from '@shared/types/api';
+import { createFestivalFormData } from '@shared/utils/form-data';
 
 export const FESTIVAL_QUERY_OPTIONS = {
   ALL: () => queryOptions({ queryKey: FESTIVAL_QUERY_KEY.ALL }),
@@ -44,50 +45,17 @@ export const getFestivalList = async (): Promise<FestivalListItem[]> => {
   return response.data.festivals.map(toFestivalListItem);
 };
 
-const createFormData = (
-  festival: FestivalCreateDTO | FestivalUpdateDTO,
-): FormData => {
-  const formData = new FormData();
-
-  if (festival.posterImg) {
-    formData.append('posterImg', festival.posterImg);
-  }
-  if (festival.logoImg) {
-    formData.append('logoImg', festival.logoImg);
-  }
-  if (festival.reservationUrls) {
-    festival.reservationUrls.forEach((url, index) => {
-      if (url.logoImg) {
-        formData.append(`reservationUrls[${index}].logoImg`, url.logoImg);
-      }
-    });
-  }
-
-  const jsonData = {
-    ...festival,
-    posterImg: undefined,
-    logoImg: undefined,
-    reservationUrls: festival.reservationUrls?.map((url) => ({
-      ...url,
-      logoImg: undefined,
-    })),
-  };
-  formData.append('data', JSON.stringify(jsonData));
-
-  return formData;
-};
-
 export const postFestival = async (
-  festival: FestivalCreateDTO,
+  festival: FestivalCreateDTO | FestivalUpdateDTO,
 ): Promise<void> => {
-  const formData = createFormData(festival);
+  const formData = createFestivalFormData(festival);
   await post(END_POINT.FESTIVAL, formData);
 };
 
 export const patchFestival = async (
   festivalId: number,
-  festival: FestivalUpdateDTO,
+  festival: FestivalCreateDTO | FestivalUpdateDTO,
 ): Promise<void> => {
-  const formData = createFormData(festival);
+  const formData = createFestivalFormData(festival);
   await patch(END_POINT.FESTIVAL_DETAIL(festivalId), formData);
 };

--- a/apps/admin/src/shared/components/form/concert-form-fields.tsx
+++ b/apps/admin/src/shared/components/form/concert-form-fields.tsx
@@ -47,72 +47,72 @@ export const ConcertBasicFormField = ({ register, errors, control }: Props) => {
 
       <div className={styles.inputContainer}>
         <FormInput
-          {...register('startDate')}
+          {...register('startAt')}
           type="date"
           label="콘서트 시작일"
-          error={errors.startDate?.message}
+          error={errors.startAt?.message}
         />
         <FormInput
-          {...register('endDate')}
+          {...register('endAt')}
           type="date"
           label="콘서트 종료일"
-          error={errors.endDate?.message}
+          error={errors.endAt?.message}
         />
       </div>
 
       <div className={styles.inputContainer}>
         <FormInput
-          {...register('location')}
+          {...register('area')}
           type="text"
           label="콘서트 장소"
           placeholder="ex) 올림픽공원 SK 핸드볼경기장"
-          error={errors.location?.message}
+          error={errors.area?.message}
         />
         <FormInput
-          {...register('reservationDate')}
+          {...register('reserveAt')}
           type="date"
           label="예매 시작일"
-          error={errors.reservationDate?.message}
+          error={errors.reserveAt?.message}
         />
       </div>
 
       <div className={styles.inputContainer}>
         <FormInput
-          {...register('ageLimit')}
+          {...register('ageRating')}
           type="text"
           label="연령 제한"
           placeholder="ex) 만 18세 이상"
-          error={errors.ageLimit?.message}
+          error={errors.ageRating?.message}
         />
         <FormInput
-          {...register('concertTime')}
+          {...register('time')}
           type="time"
           label="공연 시간"
-          error={errors.concertTime?.message}
+          error={errors.time?.message}
         />
       </div>
 
       <div className={styles.inputContainer}>
         <FormInput
-          {...register('concertPrice')}
+          {...register('price')}
           type="text"
           label="티켓 가격"
           placeholder="ex) VIP 150,000원 / R석 120,000원"
-          error={errors.concertPrice?.message}
+          error={errors.price?.message}
         />
         <FormInput
-          {...register('concertAddress')}
+          {...register('address')}
           type="text"
           label="상세 주소"
           placeholder="서울시 송파구 올림픽로 424"
-          error={errors.concertAddress?.message}
+          error={errors.address?.message}
         />
       </div>
 
       <div className={styles.singleInputContainer}>
         <Controller
           control={control}
-          name="posterImage"
+          name="posterImg"
           render={({ field }) => (
             <>
               <FormInput
@@ -124,7 +124,7 @@ export const ConcertBasicFormField = ({ register, errors, control }: Props) => {
                   setPosterFile(file);
                   field.onChange(file);
                 }}
-                error={errors.posterImage?.message}
+                error={errors.posterImg?.message}
               />
 
               {posterPreview && (
@@ -151,7 +151,7 @@ export const ConcertReservationFormField = ({
 }: Props) => {
   const { fields, append, remove } = useFieldArray({
     control,
-    name: 'reservationLinks',
+    name: 'reservationUrls',
   });
 
   return (
@@ -177,35 +177,31 @@ export const ConcertReservationFormField = ({
 
           <div className={styles.inputContainer}>
             <FormInput
-              {...register(`reservationLinks.${index}.reservationUrl`)}
+              {...register(`reservationUrls.${index}.reservationUrl`)}
               type="url"
               label="예매 URL"
               placeholder="https://ticket.example.com"
-              error={errors.reservationLinks?.[index]?.reservationUrl?.message}
+              error={errors.reservationUrls?.[index]?.reservationUrl?.message}
             />
             <FormInput
-              {...register(`reservationLinks.${index}.reservationSiteName`)}
+              {...register(`reservationUrls.${index}.name`)}
               type="text"
               label="예매 사이트명"
               placeholder="ex) 인터파크 티켓"
-              error={
-                errors.reservationLinks?.[index]?.reservationSiteName?.message
-              }
+              error={errors.reservationUrls?.[index]?.name?.message}
             />
           </div>
 
           <Controller
             control={control}
-            name={`reservationLinks.${index}.reservationSiteLogo`}
+            name={`reservationUrls.${index}.logoImg`}
             render={({ field }) => (
               <FormInput
                 type="file"
                 label="사이트 로고"
                 accept="image/*"
                 placeholder="로고 이미지를 선택해주세요"
-                error={
-                  errors.reservationLinks?.[index]?.reservationSiteLogo?.message
-                }
+                error={errors.reservationUrls?.[index]?.logoImg?.message}
                 onChange={(e) => {
                   const file = e.target.files?.[0];
                   field.onChange(file);
@@ -222,8 +218,8 @@ export const ConcertReservationFormField = ({
           onClick={() =>
             append({
               reservationUrl: '',
-              reservationSiteName: '',
-              reservationSiteLogo: new File([], ''),
+              name: '',
+              logoImg: new File([], ''),
             })
           }
           className={styles.addButton}
@@ -267,11 +263,11 @@ export const ConcertArtistFormField = ({
           </div>
 
           <FormInput
-            {...register(`artistIds.${index}.value`)}
+            {...register(`artistIds.${index}.artistId`)}
             type="text"
             label="아티스트 ID"
             placeholder="아티스트 고유 ID를 입력해주세요"
-            error={errors.artistIds?.[index]?.value?.message}
+            error={errors.artistIds?.[index]?.artistId?.message}
           />
         </div>
       ))}
@@ -279,7 +275,7 @@ export const ConcertArtistFormField = ({
       <div className={styles.buttonContainer}>
         <button
           type="button"
-          onClick={() => append({ value: '' })}
+          onClick={() => append({ artistId: '' })}
           className={styles.addButton}
         >
           + 아티스트 추가

--- a/apps/admin/src/shared/components/form/concert-form-fields.tsx
+++ b/apps/admin/src/shared/components/form/concert-form-fields.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import {
   Control,
   Controller,
@@ -21,8 +20,8 @@ interface Props {
 }
 
 export const ConcertBasicFormField = ({ register, errors, control }: Props) => {
-  const [posterFile, setPosterFile] = useState<File | null>(null);
-  const posterPreview = useImagePreview(posterFile);
+  const { preview: posterPreview, handleFileChange: handlePosterChange } =
+    useImagePreview();
 
   return (
     <div className={styles.fieldSection}>
@@ -121,7 +120,7 @@ export const ConcertBasicFormField = ({ register, errors, control }: Props) => {
                 accept="image/*"
                 onChange={(e) => {
                   const file = e.target.files?.[0] ?? null;
-                  setPosterFile(file);
+                  handlePosterChange(file);
                   field.onChange(file);
                 }}
                 error={errors.posterImg?.message}

--- a/apps/admin/src/shared/components/form/festival-date-form-fields.css.ts
+++ b/apps/admin/src/shared/components/form/festival-date-form-fields.css.ts
@@ -20,7 +20,7 @@ export const tab = style({
   backgroundColor: 'transparent',
   border: 'none',
   cursor: 'pointer',
-  fontSize: themeVars.fontSize.body2,
+  fontSize: themeVars.fontSize.body3,
   fontWeight: themeVars.fontWeight.medium,
   color: themeVars.color.gray600,
   position: 'relative',
@@ -55,7 +55,7 @@ export const activeTab = style([
 export const subSection = style({
   ...themeVars.display.flexColumn,
   gap: '1rem',
-  padding: '2rem',
+  padding: '1rem 2rem 2rem 2rem',
   marginBottom: '2rem',
   backgroundColor: themeVars.color.gray100,
   borderRadius: '12px',

--- a/apps/admin/src/shared/components/form/festival-date-form-fields.tsx
+++ b/apps/admin/src/shared/components/form/festival-date-form-fields.tsx
@@ -85,11 +85,9 @@ export const FestivalDateField = ({
         type="button"
         onClick={() =>
           appendSchedule({
-            stages: [
-              { startTime: '', endTime: '', artistIds: [{ artistId: '' }] },
-              { startTime: '', endTime: '', artistIds: [{ artistId: '' }] },
-              { startTime: '', endTime: '', artistIds: [{ artistId: '' }] },
-            ],
+            name: '',
+            order: '',
+            times: [{ startAt: '', endAt: '', artists: [{ artistId: '' }] }],
           })
         }
         className={styles.addButton}
@@ -180,13 +178,13 @@ export const StageContentField = ({
 }: StageContentFieldProps) => {
   const stageFields = useFieldArray({
     control,
-    name: `dates.${dateIndex}.stages.${scheduleIndex}.stages.${stageIndex}.artistIds`,
+    name: `dates.${dateIndex}.stages.${scheduleIndex}.times.${stageIndex}.artists`,
   });
 
   const startTimeFieldName =
-    `dates.${dateIndex}.stages.${scheduleIndex}.stages.${stageIndex}.startTime` as const;
+    `dates.${dateIndex}.stages.${scheduleIndex}.times.${stageIndex}.startAt` as const;
   const endTimeFieldName =
-    `dates.${dateIndex}.stages.${scheduleIndex}.stages.${stageIndex}.endTime` as const;
+    `dates.${dateIndex}.stages.${scheduleIndex}.times.${stageIndex}.endAt` as const;
 
   return (
     <div className={styles.stageContent}>
@@ -207,6 +205,7 @@ export const StageContentField = ({
         <Controller
           control={control}
           name={startTimeFieldName}
+          defaultValue=""
           render={({ field }) => (
             <FormInput
               {...field}
@@ -214,9 +213,9 @@ export const StageContentField = ({
               label={'공연 시작 시간'}
               placeholder="공연 시작 시간을 입력해주세요."
               error={
-                errors.dates?.[dateIndex]?.stages?.[scheduleIndex]?.stages?.[
+                errors.dates?.[dateIndex]?.stages?.[scheduleIndex]?.times?.[
                   stageIndex
-                ]?.startTime?.message
+                ]?.startAt?.message
               }
             />
           )}
@@ -224,6 +223,7 @@ export const StageContentField = ({
         <Controller
           control={control}
           name={endTimeFieldName}
+          defaultValue=""
           render={({ field }) => (
             <FormInput
               {...field}
@@ -231,9 +231,9 @@ export const StageContentField = ({
               label={'공연 종료 시간'}
               placeholder="공연 종료 시간을 입력해주세요."
               error={
-                errors.dates?.[dateIndex]?.stages?.[scheduleIndex]?.stages?.[
+                errors.dates?.[dateIndex]?.stages?.[scheduleIndex]?.times?.[
                   stageIndex
-                ]?.endTime?.message
+                ]?.endAt?.message
               }
             />
           )}
@@ -244,15 +244,15 @@ export const StageContentField = ({
         <div key={artist.id} className={styles.artistInputContainer}>
           <FormInput
             {...register(
-              `dates.${dateIndex}.stages.${scheduleIndex}.stages.${stageIndex}.artistIds.${artistIndex}.artistId`,
+              `dates.${dateIndex}.stages.${scheduleIndex}.times.${stageIndex}.artists.${artistIndex}.artistId`,
             )}
             type="text"
             label={`아티스트 ID ${artistIndex + 1}`}
             placeholder="아티스트 ID를 입력해주세요."
             error={
-              errors.dates?.[dateIndex]?.stages?.[scheduleIndex]?.stages?.[
+              errors.dates?.[dateIndex]?.stages?.[scheduleIndex]?.times?.[
                 stageIndex
-              ]?.artistIds?.[artistIndex]?.artistId?.message
+              ]?.artists?.[artistIndex]?.artistId?.message
             }
           />
           <button

--- a/apps/admin/src/shared/components/form/festival-date-form-fields.tsx
+++ b/apps/admin/src/shared/components/form/festival-date-form-fields.tsx
@@ -34,7 +34,7 @@ export const FestivalDateField = ({
     remove: removeSchedule,
   } = useFieldArray({
     control,
-    name: `festivalDates.${dateIndex}.schedules`,
+    name: `dates.${dateIndex}.stages`,
   });
 
   return (
@@ -56,16 +56,16 @@ export const FestivalDateField = ({
 
       <div className={styles.inputContainer}>
         <FormInput
-          {...register(`festivalDates.${dateIndex}.date`)}
+          {...register(`dates.${dateIndex}.festivalAt`)}
           type="date"
           label="페스티벌 날짜"
-          error={errors.festivalDates?.[dateIndex]?.date?.message}
+          error={errors.dates?.[dateIndex]?.festivalAt?.message}
         />
         <FormInput
-          {...register(`festivalDates.${dateIndex}.ticketOpenTime`)}
+          {...register(`dates.${dateIndex}.openAt`)}
           type="time"
           label="티켓 오픈 시간"
-          error={errors.festivalDates?.[dateIndex]?.ticketOpenTime?.message}
+          error={errors.dates?.[dateIndex]?.openAt?.message}
         />
       </div>
 
@@ -86,9 +86,9 @@ export const FestivalDateField = ({
         onClick={() =>
           appendSchedule({
             stages: [
-              { startTime: '', endTime: '', artistIds: [{ value: '' }] },
-              { startTime: '', endTime: '', artistIds: [{ value: '' }] },
-              { startTime: '', endTime: '', artistIds: [{ value: '' }] },
+              { startTime: '', endTime: '', artistIds: [{ artistId: '' }] },
+              { startTime: '', endTime: '', artistIds: [{ artistId: '' }] },
+              { startTime: '', endTime: '', artistIds: [{ artistId: '' }] },
             ],
           })
         }
@@ -180,13 +180,13 @@ export const StageContentField = ({
 }: StageContentFieldProps) => {
   const stageFields = useFieldArray({
     control,
-    name: `festivalDates.${dateIndex}.schedules.${scheduleIndex}.stages.${stageIndex}.artistIds`,
+    name: `dates.${dateIndex}.stages.${scheduleIndex}.stages.${stageIndex}.artistIds`,
   });
 
   const startTimeFieldName =
-    `festivalDates.${dateIndex}.schedules.${scheduleIndex}.stages.${stageIndex}.startTime` as const;
+    `dates.${dateIndex}.stages.${scheduleIndex}.stages.${stageIndex}.startTime` as const;
   const endTimeFieldName =
-    `festivalDates.${dateIndex}.schedules.${scheduleIndex}.stages.${stageIndex}.endTime` as const;
+    `dates.${dateIndex}.stages.${scheduleIndex}.stages.${stageIndex}.endTime` as const;
 
   return (
     <div className={styles.stageContent}>
@@ -214,8 +214,9 @@ export const StageContentField = ({
               label={'공연 시작 시간'}
               placeholder="공연 시작 시간을 입력해주세요."
               error={
-                errors.festivalDates?.[dateIndex]?.schedules?.[scheduleIndex]
-                  ?.stages?.[stageIndex]?.startTime?.message
+                errors.dates?.[dateIndex]?.stages?.[scheduleIndex]?.stages?.[
+                  stageIndex
+                ]?.startTime?.message
               }
             />
           )}
@@ -230,8 +231,9 @@ export const StageContentField = ({
               label={'공연 종료 시간'}
               placeholder="공연 종료 시간을 입력해주세요."
               error={
-                errors.festivalDates?.[dateIndex]?.schedules?.[scheduleIndex]
-                  ?.stages?.[stageIndex]?.endTime?.message
+                errors.dates?.[dateIndex]?.stages?.[scheduleIndex]?.stages?.[
+                  stageIndex
+                ]?.endTime?.message
               }
             />
           )}
@@ -242,14 +244,15 @@ export const StageContentField = ({
         <div key={artist.id} className={styles.artistInputContainer}>
           <FormInput
             {...register(
-              `festivalDates.${dateIndex}.schedules.${scheduleIndex}.stages.${stageIndex}.artistIds.${artistIndex}.value`,
+              `dates.${dateIndex}.stages.${scheduleIndex}.stages.${stageIndex}.artistIds.${artistIndex}.artistId`,
             )}
             type="text"
             label={`아티스트 ID ${artistIndex + 1}`}
             placeholder="아티스트 ID를 입력해주세요."
             error={
-              errors.festivalDates?.[dateIndex]?.schedules?.[scheduleIndex]
-                ?.stages?.[stageIndex]?.artistIds?.[artistIndex]?.value?.message
+              errors.dates?.[dateIndex]?.stages?.[scheduleIndex]?.stages?.[
+                stageIndex
+              ]?.artistIds?.[artistIndex]?.artistId?.message
             }
           />
           <button
@@ -265,7 +268,7 @@ export const StageContentField = ({
       <button
         type="button"
         className={styles.addButton}
-        onClick={() => stageFields.append({ value: '' })}
+        onClick={() => stageFields.append({ artistId: '' })}
       >
         아티스트 추가
       </button>

--- a/apps/admin/src/shared/components/form/festival-date-form-fields.tsx
+++ b/apps/admin/src/shared/components/form/festival-date-form-fields.tsx
@@ -92,7 +92,7 @@ export const FestivalDateField = ({
         }
         className={styles.addButton}
       >
-        공연 시간 추가
+        + 공연 시간 추가
       </button>
     </div>
   );
@@ -270,7 +270,7 @@ export const StageContentField = ({
         className={styles.addButton}
         onClick={() => stageFields.append({ artistId: '' })}
       >
-        아티스트 추가
+        + 아티스트 추가
       </button>
     </div>
   );

--- a/apps/admin/src/shared/components/form/festival-form-fields.tsx
+++ b/apps/admin/src/shared/components/form/festival-form-fields.tsx
@@ -52,68 +52,68 @@ export const FestivalBasicFormField = ({
       </div>
       <div className={styles.inputContainer}>
         <FormInput
-          {...register('startDate')}
+          {...register('startAt')}
           type="date"
           label="페스티벌 시작일"
-          error={errors.startDate?.message}
+          error={errors.startAt?.message}
         />
         <FormInput
-          {...register('endDate')}
+          {...register('endAt')}
           type="date"
           label="페스티벌 종료일"
-          error={errors.endDate?.message}
+          error={errors.endAt?.message}
         />
       </div>
       <div className={styles.inputContainer}>
         <FormInput
-          {...register('location')}
+          {...register('area')}
           type="text"
           label="페스티벌 장소"
           placeholder="ex) 올림픽공원 SK 핸드볼경기장"
-          error={errors.location?.message}
+          error={errors.area?.message}
         />
         <FormInput
-          {...register('reservationDate')}
+          {...register('reserveAt')}
           type="date"
           label="예매 시작일"
-          error={errors.reservationDate?.message}
+          error={errors.reserveAt?.message}
         />
       </div>
       <div className={styles.inputContainer}>
         <FormInput
-          {...register('ageLimit')}
+          {...register('ageRating')}
           type="text"
           label="연령 제한"
           placeholder="ex) 만 19세 이상"
-          error={errors.ageLimit?.message}
+          error={errors.ageRating?.message}
         />
         <FormInput
-          {...register('festivalTime')}
+          {...register('time')}
           type="time"
           label="페스티벌 시간"
-          error={errors.festivalTime?.message}
+          error={errors.time?.message}
         />
       </div>
       <div className={styles.inputContainer}>
         <FormInput
-          {...register('festivalPrice')}
+          {...register('price')}
           type="text"
           label="페스티벌 가격"
           placeholder="ex) 150,000원"
-          error={errors.festivalPrice?.message}
+          error={errors.price?.message}
         />
         <FormInput
-          {...register('festivalAddress')}
+          {...register('address')}
           type="text"
           label="페스티벌 주소"
           placeholder="ex) 서울특별시 송파구 올림픽로 424"
-          error={errors.festivalAddress?.message}
+          error={errors.address?.message}
         />
       </div>
       <div className={styles.inputContainer}>
         <Controller
           control={control}
-          name="posterImage"
+          name="posterImg"
           render={({ field }) => (
             <div className={styles.imageInputContainer}>
               <FormInput
@@ -124,7 +124,7 @@ export const FestivalBasicFormField = ({
                   setPosterFile(file);
                   field.onChange(file);
                 }}
-                error={errors.posterImage?.message}
+                error={errors.posterImg?.message}
               />
               {posterPreview && (
                 <div className={styles.posterPreviewContainer}>
@@ -140,14 +140,14 @@ export const FestivalBasicFormField = ({
         />
         <Controller
           control={control}
-          name="festivalLogo"
+          name="logoImg"
           render={({ field }) => (
             <div className={styles.imageInputContainer}>
               <FormInput
                 type="file"
                 label="로고 이미지"
                 placeholder="로고 이미지를 업로드해주세요."
-                error={errors.festivalLogo?.message}
+                error={errors.logoImg?.message}
                 onChange={(e) => {
                   const file = e.target.files?.[0] ?? null;
                   setLogoFile(file);
@@ -178,7 +178,7 @@ export const FestivalStageFormField = ({
 }: Props) => {
   const { fields, append, remove } = useFieldArray({
     control,
-    name: 'festivalStages',
+    name: 'stages',
   });
 
   return (
@@ -187,18 +187,18 @@ export const FestivalStageFormField = ({
       {fields.map((field, index) => (
         <div key={field.id} className={styles.fieldGroup}>
           <FormInput
-            {...register(`festivalStages.${index}.stageTitle`)}
+            {...register(`stages.${index}.name`)}
             type="text"
             label="스테이지 이름"
             placeholder="ex) 메인 스테이지"
-            error={errors.festivalStages?.[index]?.stageTitle?.message}
+            error={errors.stages?.[index]?.name?.message}
           />
           <FormInput
-            {...register(`festivalStages.${index}.stageOrder`)}
+            {...register(`stages.${index}.order`)}
             type="text"
             label="스테이지 순서"
             placeholder="스테이지 순서를 입력해주세요."
-            error={errors.festivalStages?.[index]?.stageOrder?.message}
+            error={errors.stages?.[index]?.order?.message}
           />
           <button
             type="button"
@@ -213,7 +213,7 @@ export const FestivalStageFormField = ({
       <button
         type="button"
         className={styles.addButton}
-        onClick={() => append({ stageTitle: '', stageOrder: '' })}
+        onClick={() => append({ name: '', order: '' })}
       >
         스테이지 추가
       </button>
@@ -228,7 +228,7 @@ export const FestivalReservationFormField = ({
 }: Props) => {
   const { fields, append, remove } = useFieldArray({
     control,
-    name: 'reservationLinks',
+    name: 'reservationUrls',
   });
 
   return (
@@ -238,34 +238,30 @@ export const FestivalReservationFormField = ({
         <div key={field.id} className={styles.fieldGroup}>
           <div className={styles.inputContainer}>
             <FormInput
-              {...register(`reservationLinks.${index}.reservationUrl`)}
+              {...register(`reservationUrls.${index}.reservationUrl`)}
               type="text"
               label="예매 URL"
               placeholder="예매 URL을 입력해주세요."
-              error={errors.reservationLinks?.[index]?.reservationUrl?.message}
+              error={errors.reservationUrls?.[index]?.reservationUrl?.message}
             />
             <FormInput
-              {...register(`reservationLinks.${index}.reservationSiteName`)}
+              {...register(`reservationUrls.${index}.name`)}
               type="text"
               label="예매 사이트명"
               placeholder="예매 사이트명을 입력해주세요."
-              error={
-                errors.reservationLinks?.[index]?.reservationSiteName?.message
-              }
+              error={errors.reservationUrls?.[index]?.name?.message}
             />
           </div>
 
           <Controller
             control={control}
-            name={`reservationLinks.${index}.reservationSiteLogo`}
+            name={`reservationUrls.${index}.logoImg`}
             render={({ field }) => (
               <FormInput
                 type="file"
                 label="사이트 로고"
                 placeholder="사이트 로고를 입력해주세요."
-                error={
-                  errors.reservationLinks?.[index]?.reservationSiteLogo?.message
-                }
+                error={errors.reservationUrls?.[index]?.logoImg?.message}
                 onChange={(e) => {
                   const file = e.target.files?.[0];
                   field.onChange(file);
@@ -287,8 +283,8 @@ export const FestivalReservationFormField = ({
         onClick={() =>
           append({
             reservationUrl: '',
-            reservationSiteName: '',
-            reservationSiteLogo: new File([], ''),
+            name: '',
+            logoImg: new File([], ''),
           })
         }
         className={styles.addButton}
@@ -306,7 +302,7 @@ export const FestivalDateFormField = ({ register, errors, control }: Props) => {
     remove: removeDate,
   } = useFieldArray({
     control,
-    name: 'festivalDates',
+    name: 'dates',
   });
 
   return (
@@ -328,14 +324,14 @@ export const FestivalDateFormField = ({ register, errors, control }: Props) => {
         type="button"
         onClick={() =>
           appendDate({
-            date: '',
-            ticketOpenTime: '',
-            schedules: [
+            festivalAt: '',
+            openAt: '',
+            stages: [
               {
                 stages: [
-                  { startTime: '', endTime: '', artistIds: [{ value: '' }] },
-                  { startTime: '', endTime: '', artistIds: [{ value: '' }] },
-                  { startTime: '', endTime: '', artistIds: [{ value: '' }] },
+                  { startTime: '', endTime: '', artistIds: [{ artistId: '' }] },
+                  { startTime: '', endTime: '', artistIds: [{ artistId: '' }] },
+                  { startTime: '', endTime: '', artistIds: [{ artistId: '' }] },
                 ],
               },
             ],

--- a/apps/admin/src/shared/components/form/festival-form-fields.tsx
+++ b/apps/admin/src/shared/components/form/festival-form-fields.tsx
@@ -21,6 +21,8 @@ interface Props {
   logoPreview?: string | null;
   onPosterChange?: (file: File | null) => void;
   onLogoChange?: (file: File | null) => void;
+  reservationLogoPreview?: string | null;
+  onReservationLogoChange?: (file: File | null) => void;
 }
 
 export const FestivalBasicFormField = ({
@@ -216,7 +218,7 @@ export const FestivalStageFormField = ({
         className={styles.addButton}
         onClick={() => append({ name: '', order: '', times: [] })}
       >
-        스테이지 추가
+        + 스테이지 추가
       </button>
     </div>
   );
@@ -226,6 +228,8 @@ export const FestivalReservationFormField = ({
   register,
   errors,
   control,
+  reservationLogoPreview,
+  onReservationLogoChange,
 }: Props) => {
   const { fields, append, remove } = useFieldArray({
     control,
@@ -258,16 +262,28 @@ export const FestivalReservationFormField = ({
             control={control}
             name={`reservationUrls.${index}.logoImg`}
             render={({ field }) => (
-              <FormInput
-                type="file"
-                label="사이트 로고"
-                placeholder="사이트 로고를 입력해주세요."
-                error={errors.reservationUrls?.[index]?.logoImg?.message}
-                onChange={(e) => {
-                  const file = e.target.files?.[0];
-                  field.onChange(file);
-                }}
-              />
+              <>
+                <FormInput
+                  type="file"
+                  label="사이트 로고"
+                  placeholder="사이트 로고를 입력해주세요."
+                  error={errors.reservationUrls?.[index]?.logoImg?.message}
+                  onChange={(e) => {
+                    const file = e.target.files?.[0] ?? null;
+                    onReservationLogoChange?.(file);
+                    field.onChange(file);
+                  }}
+                />
+                {reservationLogoPreview && (
+                  <div className={styles.posterPreviewContainer}>
+                    <img
+                      src={reservationLogoPreview}
+                      alt="사이트 로고 미리보기"
+                      className={styles.posterPreview}
+                    />
+                  </div>
+                )}
+              </>
             )}
           />
           <button
@@ -290,7 +306,7 @@ export const FestivalReservationFormField = ({
         }
         className={styles.addButton}
       >
-        예매 링크 추가
+        + 예매 링크 추가
       </button>
     </div>
   );
@@ -340,7 +356,7 @@ export const FestivalDateFormField = ({ register, errors, control }: Props) => {
         }
         className={styles.addButton}
       >
-        페스티벌 날짜 추가
+        + 페스티벌 날짜 추가
       </button>
     </div>
   );

--- a/apps/admin/src/shared/components/form/festival-form-fields.tsx
+++ b/apps/admin/src/shared/components/form/festival-form-fields.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import {
   Control,
   Controller,
@@ -10,7 +9,6 @@ import { z } from 'zod';
 
 import { FestivalDateField } from '@shared/components/form/festival-date-form-fields';
 import FormInput from '@shared/components/form/form-input';
-import { useImagePreview } from '@shared/hooks/use-image-preview';
 import { festivalSchema } from '@shared/schemas/festival-schema';
 
 import * as styles from './festival-form-fields.css';
@@ -19,18 +17,21 @@ interface Props {
   register: UseFormRegister<z.infer<typeof festivalSchema>>;
   errors: FieldErrors<z.infer<typeof festivalSchema>>;
   control: Control<z.infer<typeof festivalSchema>>;
+  posterPreview?: string | null;
+  logoPreview?: string | null;
+  onPosterChange?: (file: File | null) => void;
+  onLogoChange?: (file: File | null) => void;
 }
 
 export const FestivalBasicFormField = ({
   register,
   errors,
   control,
+  posterPreview,
+  logoPreview,
+  onPosterChange,
+  onLogoChange,
 }: Props) => {
-  const [posterFile, setPosterFile] = useState<File | null>(null);
-  const [logoFile, setLogoFile] = useState<File | null>(null);
-  const posterPreview = useImagePreview(posterFile);
-  const logoPreview = useImagePreview(logoFile);
-
   return (
     <div className={styles.fieldSection}>
       <h2 className={styles.title}>기본 정보</h2>
@@ -121,7 +122,7 @@ export const FestivalBasicFormField = ({
                 label="포스터 이미지"
                 onChange={(e) => {
                   const file = e.target.files?.[0] ?? null;
-                  setPosterFile(file);
+                  onPosterChange?.(file);
                   field.onChange(file);
                 }}
                 error={errors.posterImg?.message}
@@ -150,7 +151,7 @@ export const FestivalBasicFormField = ({
                 error={errors.logoImg?.message}
                 onChange={(e) => {
                   const file = e.target.files?.[0] ?? null;
-                  setLogoFile(file);
+                  onLogoChange?.(file);
                   field.onChange(file);
                 }}
               />
@@ -178,7 +179,7 @@ export const FestivalStageFormField = ({
 }: Props) => {
   const { fields, append, remove } = useFieldArray({
     control,
-    name: 'stages',
+    name: 'dates.0.stages',
   });
 
   return (
@@ -187,18 +188,18 @@ export const FestivalStageFormField = ({
       {fields.map((field, index) => (
         <div key={field.id} className={styles.fieldGroup}>
           <FormInput
-            {...register(`stages.${index}.name`)}
+            {...register(`dates.0.stages.${index}.name`)}
             type="text"
             label="스테이지 이름"
             placeholder="ex) 메인 스테이지"
-            error={errors.stages?.[index]?.name?.message}
+            error={errors.dates?.[0]?.stages?.[index]?.name?.message}
           />
           <FormInput
-            {...register(`stages.${index}.order`)}
+            {...register(`dates.0.stages.${index}.order`)}
             type="text"
             label="스테이지 순서"
             placeholder="스테이지 순서를 입력해주세요."
-            error={errors.stages?.[index]?.order?.message}
+            error={errors.dates?.[0]?.stages?.[index]?.order?.message}
           />
           <button
             type="button"
@@ -213,7 +214,7 @@ export const FestivalStageFormField = ({
       <button
         type="button"
         className={styles.addButton}
-        onClick={() => append({ name: '', order: '' })}
+        onClick={() => append({ name: '', order: '', times: [] })}
       >
         스테이지 추가
       </button>
@@ -328,10 +329,10 @@ export const FestivalDateFormField = ({ register, errors, control }: Props) => {
             openAt: '',
             stages: [
               {
-                stages: [
-                  { startTime: '', endTime: '', artistIds: [{ artistId: '' }] },
-                  { startTime: '', endTime: '', artistIds: [{ artistId: '' }] },
-                  { startTime: '', endTime: '', artistIds: [{ artistId: '' }] },
+                name: '',
+                order: '',
+                times: [
+                  { startAt: '', endAt: '', artists: [{ artistId: '' }] },
                 ],
               },
             ],

--- a/apps/admin/src/shared/constants/api.ts
+++ b/apps/admin/src/shared/constants/api.ts
@@ -1,0 +1,8 @@
+export const END_POINT = {
+  CONCERT: '/admin/performance/concerts',
+  FESTIVAL: '/admin/performance/festivals',
+  CONCERT_DETAIL: (concertId: number) =>
+    `/admin/performance/concerts/${concertId}`,
+  FESTIVAL_DETAIL: (festivalId: number) =>
+    `/admin/performance/festivals/${festivalId}`,
+} as const;

--- a/apps/admin/src/shared/constants/config.ts
+++ b/apps/admin/src/shared/constants/config.ts
@@ -1,0 +1,6 @@
+export const ENV_CONFIG = {
+  ADMIN_BASE_URL: import.meta.env.VITE_ADMIN_BASE_URL as string,
+} as const;
+
+export const ACCESS_TOKEN_KEY = 'accessToken' as const;
+export const REFRESH_TOKEN_KEY = 'refreshToken' as const;

--- a/apps/admin/src/shared/constants/query-key.ts
+++ b/apps/admin/src/shared/constants/query-key.ts
@@ -1,0 +1,9 @@
+export const CONCERT_QUERY_KEY = {
+  ALL: ['concerts'],
+  CONCERT: (concertId: number) => [...CONCERT_QUERY_KEY.ALL, concertId],
+} as const;
+
+export const FESTIVAL_QUERY_KEY = {
+  ALL: ['festivals'],
+  FESTIVAL: (festivalId: number) => [...FESTIVAL_QUERY_KEY.ALL, festivalId],
+} as const;

--- a/apps/admin/src/shared/hooks/use-image-preview.ts
+++ b/apps/admin/src/shared/hooks/use-image-preview.ts
@@ -1,6 +1,16 @@
 import { useEffect, useState } from 'react';
 
-export const useImagePreview = (file?: File | null) => {
+interface UseImagePreviewReturn {
+  file: File | null;
+  preview: string | null;
+  setFile: (file: File | null) => void;
+  handleFileChange: (file: File | null) => void;
+}
+
+export const useImagePreview = (
+  initialFile?: File | null,
+): UseImagePreviewReturn => {
+  const [file, setFile] = useState<File | null>(initialFile ?? null);
   const [preview, setPreview] = useState<string | null>(null);
 
   useEffect(() => {
@@ -15,5 +25,14 @@ export const useImagePreview = (file?: File | null) => {
     return () => URL.revokeObjectURL(url);
   }, [file]);
 
-  return preview;
+  const handleFileChange = (newFile: File | null) => {
+    setFile(newFile);
+  };
+
+  return {
+    file,
+    preview,
+    setFile,
+    handleFileChange,
+  };
 };

--- a/apps/admin/src/shared/models/concert.ts
+++ b/apps/admin/src/shared/models/concert.ts
@@ -5,11 +5,11 @@ import {
   ReservationUrlRequestDTO,
 } from '../types/api';
 
-export type Artist = {
+type Artist = {
   artistId: string;
 };
 
-export type ReservationUrl = {
+type ReservationUrl = {
   reservationUrl: string;
   name: string;
   logoUrl: string;

--- a/apps/admin/src/shared/models/concert.ts
+++ b/apps/admin/src/shared/models/concert.ts
@@ -1,0 +1,110 @@
+import {
+  ConcertCreateDTO,
+  ConcertDetailDTO,
+  ConcertListDTO,
+  ReservationUrlRequestDTO,
+} from '../types/api';
+
+export type Artist = {
+  artistId: string;
+};
+
+export type ReservationUrl = {
+  reservationUrl: string;
+  name: string;
+  logoUrl: string;
+  logoImg?: File;
+};
+
+export type Concert = {
+  title: string;
+  subtitle: string;
+  posterUrl: string;
+  posterImg?: File;
+  startAt: Date;
+  endAt: Date;
+  area: string;
+  reserveAt: Date;
+  ageRating: string;
+  time: string;
+  price: string;
+  address: string;
+  artists: Artist[];
+  reservationUrls: ReservationUrl[];
+};
+
+export type ConcertListItem = {
+  concertId: number;
+  title: string;
+  subtitle: string;
+  startAt: Date;
+  area: string;
+  reserveAt: Date;
+};
+
+export function toConcert(dto: ConcertDetailDTO): Concert {
+  return {
+    title: dto.concert.title,
+    subtitle: dto.concert.subtitle,
+    posterUrl: dto.concert.posterUrl,
+    startAt: new Date(dto.concert.startAt),
+    endAt: new Date(dto.concert.endAt),
+    area: dto.concert.area,
+    reserveAt: new Date(dto.concert.reserveAt),
+    ageRating: dto.concert.ageRating,
+    time: dto.concert.time,
+    price: dto.concert.price,
+    address: dto.concert.address,
+    artists: dto.concert.artists,
+    reservationUrls: dto.concert.reservationUrls.map((url) => ({
+      ...url,
+      logoUrl: url.logoUrl,
+    })),
+  };
+}
+
+export function toConcertListItem(
+  dto: ConcertListDTO['concerts'][0],
+): ConcertListItem {
+  return {
+    concertId: dto.concertId,
+    title: dto.title,
+    subtitle: dto.subtitle,
+    startAt: new Date(dto.startAt),
+    area: dto.area,
+    reserveAt: new Date(dto.reserveAt),
+  };
+}
+
+export function toConcertCreateDTO(concert: Concert): ConcertCreateDTO {
+  if (!concert.posterImg) {
+    throw new Error('포스터 이미지가 필요합니다.');
+  }
+
+  const reservationUrls = concert.reservationUrls.map((url) => {
+    if (!url.logoImg) {
+      throw new Error('예약 링크 로고 이미지가 필요합니다.');
+    }
+    return {
+      reservationUrl: url.reservationUrl,
+      name: url.name,
+      logoImg: url.logoImg,
+    } as ReservationUrlRequestDTO;
+  });
+
+  return {
+    title: concert.title,
+    subtitle: concert.subtitle,
+    posterImg: concert.posterImg,
+    startAt: concert.startAt.toISOString().split('T')[0], // yyyy-MM-dd
+    endAt: concert.endAt.toISOString().split('T')[0], // yyyy-MM-dd
+    area: concert.area,
+    reserveAt: concert.reserveAt.toISOString(), // yyyy-MM-dd'T'HH:mm:ss
+    ageRating: concert.ageRating,
+    time: concert.time,
+    price: concert.price,
+    address: concert.address,
+    artists: concert.artists,
+    reservationUrls,
+  };
+}

--- a/apps/admin/src/shared/models/festival.ts
+++ b/apps/admin/src/shared/models/festival.ts
@@ -1,0 +1,71 @@
+import { FestivalDetailDTO, FestivalListDTO } from '../types/api';
+
+type Artist = {
+  artistId: string;
+};
+
+type ReservationUrl = {
+  reservationUrl: string;
+  name: string;
+  logoUrl: string;
+  logoImg?: File;
+};
+
+export type FestivalListItem = {
+  id: number;
+  title: string;
+  subtitle: string;
+  startAt: Date;
+  area: string;
+  reserveAt: Date;
+};
+
+export type Festival = {
+  title: string;
+  subtitle: string;
+  posterUrl: string;
+  startAt: Date;
+  endAt: Date;
+  area: string;
+  reserveAt: Date;
+  ageRating: string;
+  time: string;
+  price: string;
+  address: string;
+  artists: Artist[];
+  reservationUrls: ReservationUrl[];
+};
+
+export function toFestivalListItem(
+  dto: FestivalListDTO['festivals'][0],
+): FestivalListItem {
+  return {
+    id: dto.festivalId,
+    title: dto.title,
+    subtitle: dto.subtitle,
+    startAt: new Date(dto.startAt),
+    area: dto.area,
+    reserveAt: new Date(dto.reserveAt),
+  };
+}
+
+export function toFestival(dto: FestivalDetailDTO): Festival {
+  return {
+    title: dto.title,
+    subtitle: dto.subtitle,
+    posterUrl: dto.posterUrl,
+    startAt: new Date(dto.startAt),
+    endAt: new Date(dto.endAt),
+    area: dto.area,
+    reserveAt: new Date(dto.reserveAt),
+    ageRating: dto.ageRating,
+    time: dto.time,
+    price: dto.price,
+    address: dto.address,
+    artists: dto.artists,
+    reservationUrls: dto.reservationUrls.map((url) => ({
+      ...url,
+      logoUrl: url.logoUrl,
+    })),
+  };
+}

--- a/apps/admin/src/shared/models/festival.ts
+++ b/apps/admin/src/shared/models/festival.ts
@@ -23,6 +23,8 @@ export type FestivalListItem = {
 export type Festival = {
   title: string;
   subtitle: string;
+  posterImg?: File;
+  logoImg?: File;
   posterUrl: string;
   startAt: Date;
   endAt: Date;

--- a/apps/admin/src/shared/schemas/concert-schema.ts
+++ b/apps/admin/src/shared/schemas/concert-schema.ts
@@ -5,29 +5,29 @@ import { z } from 'zod';
 export const concertSchema = z.object({
   title: z.string().min(1, '제목을 입력해주세요'),
   subTitle: z.string().min(1, '부제목을 입력해주세요'),
-  startDate: z.string().min(1, '시작일을 선택해주세요'),
-  endDate: z.string().min(1, '종료일을 선택해주세요'),
-  location: z.string().min(1, '장소를 입력해주세요'),
-  reservationDate: z.string().min(1, '예매일을 선택해주세요'),
-  ageLimit: z.string().min(1, '연령제한을 입력해주세요'),
-  concertTime: z.string().min(1, '공연 시간을 입력해주세요'),
-  concertPrice: z.string().min(1, '가격을 입력해주세요'),
-  concertAddress: z.string().min(1, '주소를 입력해주세요'),
-  posterImage: z.instanceof(File).refine((file) => file.size > 0, {
+  startAt: z.string().min(1, '시작일을 선택해주세요'),
+  endAt: z.string().min(1, '종료일을 선택해주세요'),
+  area: z.string().min(1, '장소를 입력해주세요'),
+  reserveAt: z.string().min(1, '예매일을 선택해주세요'),
+  ageRating: z.string().min(1, '연령제한을 입력해주세요'),
+  time: z.string().min(1, '공연 시간을 입력해주세요'),
+  price: z.string().min(1, '가격을 입력해주세요'),
+  address: z.string().min(1, '주소를 입력해주세요'),
+  posterImg: z.instanceof(File).refine((file) => file.size > 0, {
     message: '포스터 이미지를 업로드해주세요',
   }),
-  reservationLinks: z.array(
+  reservationUrls: z.array(
     z.object({
       reservationUrl: z.string().min(1, '예매 URL을 입력해주세요'),
-      reservationSiteName: z.string().min(1, '예매 사이트명을 입력해주세요'),
-      reservationSiteLogo: z.instanceof(File).refine((file) => file.size > 0, {
+      name: z.string().min(1, '예매 사이트명을 입력해주세요'),
+      logoImg: z.instanceof(File).refine((file) => file.size > 0, {
         message: '사이트 로고를 업로드해주세요',
       }),
     }),
   ),
   artistIds: z.array(
     z.object({
-      value: z.string().min(1, '아티스트 ID를 입력해주세요'),
+      artistId: z.string().min(1, '아티스트 ID를 입력해주세요'),
     }),
   ),
 });
@@ -37,21 +37,21 @@ export const concertDefaultValues: DefaultValues<
 > = {
   title: '',
   subTitle: '',
-  startDate: '',
-  endDate: '',
-  location: '',
-  reservationDate: '',
-  ageLimit: '',
-  concertTime: '',
-  concertPrice: '',
-  concertAddress: '',
-  posterImage: new File([], ''),
-  reservationLinks: [
+  startAt: '',
+  endAt: '',
+  area: '',
+  reserveAt: '',
+  ageRating: '',
+  time: '',
+  price: '',
+  address: '',
+  posterImg: new File([], ''),
+  reservationUrls: [
     {
       reservationUrl: '',
-      reservationSiteName: '',
-      reservationSiteLogo: new File([], ''),
+      name: '',
+      logoImg: new File([], ''),
     },
   ],
-  artistIds: [{ value: '' }],
+  artistIds: [{ artistId: '' }],
 };

--- a/apps/admin/src/shared/schemas/festival-schema.ts
+++ b/apps/admin/src/shared/schemas/festival-schema.ts
@@ -5,40 +5,40 @@ import { z } from 'zod';
 export const festivalSchema = z.object({
   title: z.string().min(1, '제목을 입력해주세요'),
   subTitle: z.string().min(1, '부제목을 입력해주세요'),
-  startDate: z.string().min(1, '시작일을 선택해주세요'),
-  endDate: z.string().min(1, '종료일을 선택해주세요'),
-  location: z.string().min(1, '장소를 입력해주세요'),
-  reservationDate: z.string().min(1, '예매일을 선택해주세요'),
-  ageLimit: z.string().min(1, '연령제한을 입력해주세요'),
-  festivalTime: z.string().min(1, '공연 시간을 입력해주세요'),
-  festivalPrice: z.string().min(1, '가격을 입력해주세요'),
-  festivalAddress: z.string().min(1, '주소를 입력해주세요'),
-  posterImage: z.instanceof(File).refine((file) => file.size > 0, {
+  startAt: z.string().min(1, '시작일을 선택해주세요'),
+  endAt: z.string().min(1, '종료일을 선택해주세요'),
+  area: z.string().min(1, '장소를 입력해주세요'),
+  reserveAt: z.string().min(1, '예매일을 선택해주세요'),
+  ageRating: z.string().min(1, '연령제한을 입력해주세요'),
+  time: z.string().min(1, '공연 시간을 입력해주세요'),
+  price: z.string().min(1, '가격을 입력해주세요'),
+  address: z.string().min(1, '주소를 입력해주세요'),
+  posterImg: z.instanceof(File).refine((file) => file.size > 0, {
     message: '포스터 이미지를 업로드해주세요',
   }),
-  festivalLogo: z.instanceof(File).refine((file) => file.size > 0, {
+  logoImg: z.instanceof(File).refine((file) => file.size > 0, {
     message: '로고 이미지를 업로드해주세요',
   }),
-  reservationLinks: z.array(
+  reservationUrls: z.array(
     z.object({
       reservationUrl: z.string().min(1, '예매 URL을 입력해주세요'),
-      reservationSiteName: z.string().min(1, '예매 사이트명을 입력해주세요'),
-      reservationSiteLogo: z.instanceof(File).refine((file) => file.size > 0, {
+      name: z.string().min(1, '예매 사이트명을 입력해주세요'),
+      logoImg: z.instanceof(File).refine((file) => file.size > 0, {
         message: '로고 이미지를 업로드해주세요',
       }),
     }),
   ),
-  festivalStages: z.array(
+  stages: z.array(
     z.object({
-      stageTitle: z.string().min(1, '스테이지 이름을 입력해주세요'),
-      stageOrder: z.string().min(1, '스테이지 순서를 입력해주세요'),
+      name: z.string().min(1, '스테이지 이름을 입력해주세요'),
+      order: z.string().min(1, '스테이지 순서를 입력해주세요'),
     }),
   ),
-  festivalDates: z.array(
+  dates: z.array(
     z.object({
-      date: z.string().min(1, '페스티벌 날짜를 입력해주세요'),
-      ticketOpenTime: z.string().min(1, '티켓 오픈 시간을 입력해주세요'),
-      schedules: z.array(
+      festivalAt: z.string().min(1, '페스티벌 날짜를 입력해주세요'),
+      openAt: z.string().min(1, '티켓 오픈 시간을 입력해주세요'),
+      stages: z.array(
         z.object({
           stages: z
             .array(
@@ -47,7 +47,7 @@ export const festivalSchema = z.object({
                 endTime: z.string().min(1, '공연 종료 시간을 입력해주세요'),
                 artistIds: z.array(
                   z.object({
-                    value: z.string().min(1, '아티스트 ID를 입력해주세요'),
+                    artistId: z.string().min(1, '아티스트 ID를 입력해주세요'),
                   }),
                 ),
               }),
@@ -64,39 +64,39 @@ export const festivalDefaultValues: DefaultValues<
 > = {
   title: '',
   subTitle: '',
-  startDate: '',
-  endDate: '',
-  location: '',
-  reservationDate: '',
-  ageLimit: '',
-  festivalTime: '',
-  festivalPrice: '',
-  festivalAddress: '',
-  posterImage: new File([], ''),
-  festivalLogo: new File([], ''),
-  festivalStages: [
+  startAt: '',
+  endAt: '',
+  area: '',
+  reserveAt: '',
+  ageRating: '',
+  time: '',
+  price: '',
+  address: '',
+  posterImg: new File([], ''),
+  logoImg: new File([], ''),
+  stages: [
     {
-      stageTitle: '',
-      stageOrder: '',
+      name: '',
+      order: '',
     },
   ],
-  reservationLinks: [
+  reservationUrls: [
     {
       reservationUrl: '',
-      reservationSiteName: '',
-      reservationSiteLogo: new File([], ''),
+      name: '',
+      logoImg: new File([], ''),
     },
   ],
-  festivalDates: [
+  dates: [
     {
-      date: '',
-      ticketOpenTime: '',
-      schedules: [
+      festivalAt: '',
+      openAt: '',
+      stages: [
         {
           stages: [
-            { startTime: '', endTime: '', artistIds: [{ value: '' }] },
-            { startTime: '', endTime: '', artistIds: [{ value: '' }] },
-            { startTime: '', endTime: '', artistIds: [{ value: '' }] },
+            { startTime: '', endTime: '', artistIds: [{ artistId: '' }] },
+            { startTime: '', endTime: '', artistIds: [{ artistId: '' }] },
+            { startTime: '', endTime: '', artistIds: [{ artistId: '' }] },
           ],
         },
       ],

--- a/apps/admin/src/shared/schemas/festival-schema.ts
+++ b/apps/admin/src/shared/schemas/festival-schema.ts
@@ -28,31 +28,26 @@ export const festivalSchema = z.object({
       }),
     }),
   ),
-  stages: z.array(
-    z.object({
-      name: z.string().min(1, '스테이지 이름을 입력해주세요'),
-      order: z.string().min(1, '스테이지 순서를 입력해주세요'),
-    }),
-  ),
+
   dates: z.array(
     z.object({
       festivalAt: z.string().min(1, '페스티벌 날짜를 입력해주세요'),
       openAt: z.string().min(1, '티켓 오픈 시간을 입력해주세요'),
       stages: z.array(
         z.object({
-          stages: z
-            .array(
-              z.object({
-                startTime: z.string().min(1, '공연 시작 시간을 입력해주세요'),
-                endTime: z.string().min(1, '공연 종료 시간을 입력해주세요'),
-                artistIds: z.array(
-                  z.object({
-                    artistId: z.string().min(1, '아티스트 ID를 입력해주세요'),
-                  }),
-                ),
-              }),
-            )
-            .length(3),
+          name: z.string().min(1, '스테이지 이름을 입력해주세요'),
+          order: z.string().min(1, '스테이지 순서를 입력해주세요'),
+          times: z.array(
+            z.object({
+              startAt: z.string().min(1, '공연 시작 시간을 입력해주세요'),
+              endAt: z.string().min(1, '공연 종료 시간을 입력해주세요'),
+              artists: z.array(
+                z.object({
+                  artistId: z.string().min(1, '아티스트 ID를 입력해주세요'),
+                }),
+              ),
+            }),
+          ),
         }),
       ),
     }),
@@ -74,12 +69,6 @@ export const festivalDefaultValues: DefaultValues<
   address: '',
   posterImg: new File([], ''),
   logoImg: new File([], ''),
-  stages: [
-    {
-      name: '',
-      order: '',
-    },
-  ],
   reservationUrls: [
     {
       reservationUrl: '',
@@ -93,11 +82,9 @@ export const festivalDefaultValues: DefaultValues<
       openAt: '',
       stages: [
         {
-          stages: [
-            { startTime: '', endTime: '', artistIds: [{ artistId: '' }] },
-            { startTime: '', endTime: '', artistIds: [{ artistId: '' }] },
-            { startTime: '', endTime: '', artistIds: [{ artistId: '' }] },
-          ],
+          name: '',
+          order: '',
+          times: [{ startAt: '', endAt: '', artists: [{ artistId: '' }] }],
         },
       ],
     },

--- a/apps/admin/src/shared/types/api.ts
+++ b/apps/admin/src/shared/types/api.ts
@@ -2,24 +2,12 @@ export type BaseResponse<T> = {
   status: number;
   message: string;
   data: T;
-  code?: number;
 };
 
 export interface ErrorResponse {
   message?: string;
   code?: number;
 }
-
-export type ConcertListDTO = {
-  concerts: {
-    concertId: number;
-    title: string;
-    subtitle: string;
-    startAt: string;
-    area: string;
-    reserveAt: string;
-  }[];
-};
 
 export type ArtistDTO = {
   artistId: string;
@@ -37,20 +25,15 @@ export type ReservationUrlRequestDTO = {
   logoImg: File;
 };
 
-export type ConcertCreateDTO = {
-  title: string;
-  subtitle: string;
-  posterImg: File;
-  startAt: string;
-  endAt: string;
-  area: string;
-  reserveAt: string;
-  ageRating: string;
-  time: string;
-  price: string;
-  address: string;
-  artists: ArtistDTO[];
-  reservationUrls: ReservationUrlRequestDTO[];
+export type ConcertListDTO = {
+  concerts: {
+    concertId: number;
+    title: string;
+    subtitle: string;
+    startAt: string;
+    area: string;
+    reserveAt: string;
+  }[];
 };
 
 export type ConcertDetailDTO = {
@@ -70,3 +53,85 @@ export type ConcertDetailDTO = {
     reservationUrls: ReservationUrlResponseDTO[];
   };
 };
+
+export type ConcertCreateDTO = {
+  title: string;
+  subtitle: string;
+  posterImg: File;
+  startAt: string;
+  endAt: string;
+  area: string;
+  reserveAt: string;
+  ageRating: string;
+  time: string;
+  price: string;
+  address: string;
+  artists: ArtistDTO[];
+  reservationUrls: ReservationUrlRequestDTO[];
+};
+
+export type FestivalListDTO = {
+  festivals: {
+    festivalId: number;
+    title: string;
+    subtitle: string;
+    startAt: string;
+    area: string;
+    reserveAt: string;
+  }[];
+};
+
+export type FestivalDetailDTO = {
+  title: string;
+  subtitle: string;
+  posterUrl: string;
+  startAt: string;
+  endAt: string;
+  area: string;
+  reserveAt: string;
+  ageRating: string;
+  time: string;
+  price: string;
+  address: string;
+  artists: ArtistDTO[];
+  reservationUrls: ReservationUrlResponseDTO[];
+};
+
+type FestivalStageTimeDTO = {
+  startAt: string;
+  endAt: string;
+  artists: {
+    artistId: string;
+  }[];
+};
+
+type FestivalStageDTO = {
+  name: string;
+  order: number;
+  times: FestivalStageTimeDTO[];
+};
+
+type FestivalDateDTO = {
+  festivalAt: string;
+  openAt: string;
+  stages: FestivalStageDTO[];
+};
+
+export type FestivalCreateDTO = {
+  title: string;
+  subtitle: string;
+  posterImg: File;
+  logoImg: File;
+  startAt: string;
+  endAt: string;
+  area: string;
+  reserveAt: string;
+  ageRating: string;
+  time: string;
+  price: string;
+  address: string;
+  dates: FestivalDateDTO[];
+  reservationUrls: ReservationUrlRequestDTO[];
+};
+
+export type FestivalUpdateDTO = Partial<FestivalCreateDTO>;

--- a/apps/admin/src/shared/types/api.ts
+++ b/apps/admin/src/shared/types/api.ts
@@ -1,0 +1,72 @@
+export type BaseResponse<T> = {
+  status: number;
+  message: string;
+  data: T;
+  code?: number;
+};
+
+export interface ErrorResponse {
+  message?: string;
+  code?: number;
+}
+
+export type ConcertListDTO = {
+  concerts: {
+    concertId: number;
+    title: string;
+    subtitle: string;
+    startAt: string;
+    area: string;
+    reserveAt: string;
+  }[];
+};
+
+export type ArtistDTO = {
+  artistId: string;
+};
+
+export type ReservationUrlResponseDTO = {
+  reservationUrl: string;
+  name: string;
+  logoUrl: string;
+};
+
+export type ReservationUrlRequestDTO = {
+  reservationUrl: string;
+  name: string;
+  logoImg: File;
+};
+
+export type ConcertCreateDTO = {
+  title: string;
+  subtitle: string;
+  posterImg: File;
+  startAt: string;
+  endAt: string;
+  area: string;
+  reserveAt: string;
+  ageRating: string;
+  time: string;
+  price: string;
+  address: string;
+  artists: ArtistDTO[];
+  reservationUrls: ReservationUrlRequestDTO[];
+};
+
+export type ConcertDetailDTO = {
+  concert: {
+    title: string;
+    subtitle: string;
+    posterUrl: string;
+    startAt: string;
+    endAt: string;
+    area: string;
+    reserveAt: string;
+    ageRating: string;
+    time: string;
+    price: string;
+    address: string;
+    artists: ArtistDTO[];
+    reservationUrls: ReservationUrlResponseDTO[];
+  };
+};

--- a/apps/admin/src/shared/types/festival.ts
+++ b/apps/admin/src/shared/types/festival.ts
@@ -1,0 +1,46 @@
+export interface Festival {
+  festivalId: number;
+  title: string;
+  subtitle: string;
+  startAt: string;
+  area: string;
+  reserveAt: string;
+}
+
+export interface FestivalListResponse {
+  status: number;
+  message: string;
+  data: {
+    festivals: Festival[];
+  };
+}
+
+export interface FestivalDetail {
+  title: string;
+  subtitle: string;
+  posterUrl: string;
+  startAt: string;
+  endAt: string;
+  area: string;
+  reserveAt: string;
+  ageRating: string;
+  time: string;
+  price: string;
+  address: string;
+  artists: {
+    artistId: string;
+  }[];
+  reservationUrls: {
+    reservationUrl: string;
+    name: string;
+    logoUrl: string;
+  }[];
+}
+
+export interface FestivalDetailResponse {
+  status: number;
+  message: string;
+  data: {
+    concert: FestivalDetail;
+  };
+}

--- a/apps/admin/src/shared/utils/form-data.ts
+++ b/apps/admin/src/shared/utils/form-data.ts
@@ -1,0 +1,58 @@
+import { FestivalCreateDTO, FestivalUpdateDTO } from '@shared/types/api';
+
+import { Concert, toConcertCreateDTO } from '../models/concert';
+
+export const createConcertFormData = (concert: Concert): FormData => {
+  const formData = new FormData();
+  const dto = toConcertCreateDTO(concert);
+
+  formData.append('posterImg', dto.posterImg);
+  dto.reservationUrls.forEach((url, index) => {
+    formData.append(`reservationUrls[${index}].logoImg`, url.logoImg);
+  });
+
+  const jsonData = {
+    ...dto,
+    posterImg: undefined,
+    reservationUrls: dto.reservationUrls.map((url) => ({
+      ...url,
+      logoImg: undefined,
+    })),
+  };
+  formData.append('data', JSON.stringify(jsonData));
+
+  return formData;
+};
+
+export const createFestivalFormData = (
+  festival: FestivalCreateDTO | FestivalUpdateDTO,
+): FormData => {
+  const formData = new FormData();
+
+  if (festival.posterImg) {
+    formData.append('posterImg', festival.posterImg);
+  }
+  if (festival.logoImg) {
+    formData.append('logoImg', festival.logoImg);
+  }
+  if (festival.reservationUrls) {
+    festival.reservationUrls.forEach((url, index) => {
+      if (url.logoImg) {
+        formData.append(`reservationUrls[${index}].logoImg`, url.logoImg);
+      }
+    });
+  }
+
+  const jsonData = {
+    ...festival,
+    posterImg: undefined,
+    logoImg: undefined,
+    reservationUrls: festival.reservationUrls?.map((url) => ({
+      ...url,
+      logoImg: undefined,
+    })),
+  };
+  formData.append('data', JSON.stringify(jsonData));
+
+  return formData;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.2
         version: 4.5.1(vite@6.3.5(@types/node@20.19.0)(yaml@2.8.0))
+      axios:
+        specifier: ^1.7.9
+        version: 1.9.0
       react:
         specifier: ^19.0.0
         version: 19.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.1.1
         version: 5.1.1(react-hook-form@7.57.0(react@19.1.0))
+      '@tanstack/react-query':
+        specifier: ^5.62.16
+        version: 5.80.6(react@19.1.0)
       '@types/react':
         specifier: ^19.0.0
         version: 19.0.0


### PR DESCRIPTION
## 📌 Summary

> - #584 

## 📚 Tasks

- 명세서 형식으로 스키마 수정
- TanStack Query, axios 세팅
- 콘서트/페스티벌 관련 API 세팅

## 👀 To Reviewer

### 타입 중심 설계

API 타입 정의를 단순 요청용이 아닌, 도메인 모델까지 연결되는 구조로 설계했어요.

- DTO(Data Transfer Object) 타입과 도메인 모델 분리
→ API에서 받은 데이터와 화면에서 실제 사용하는 데이터 모델을 분리하여, 각 레이어의 역할을 명확히 했어요.

- UI 컴포넌트까지 타입 흐름 연결
→ API 타입 → 도메인 모델 → UI props까지 일관된 타입 흐름이 이어지도록 구성했어요. 이로 인해 props에서의 타입 재사용성과 자동 완성의 효율이 높아질 것이라 생각해요.

ref) https://velog.io/@rewq5991/typescript-project-design

### 공통 config/core packages의 필요성

axios instance 등 core한 부분을 공통적으로 패키지화해서 설정할 필요성을 느꼈어요.
admin과 client에서 반복되는 설정(인터셉터, 에러처리, ..)을 추후 task에서 설계해 분리해둬야할 것 같아요.
