### PR TITLE
Fix(client): 추가할 페스티벌 없을 때 분기 처리

### DIFF
--- a/apps/client/src/pages/timetable/components/festival-selector/festival-selector.tsx
+++ b/apps/client/src/pages/timetable/components/festival-selector/festival-selector.tsx
@@ -1,8 +1,10 @@
 import { useNavigate } from 'react-router-dom';
 import FestivalButton from '@pages/timetable/components/festival-selector/festival-button';
+import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 
 import { DropdownMenu } from '@confeti/design-system';
 import { Icon } from '@confeti/design-system/icon';
+import { FESTIVAL_TIMETABLE_QUERY_OPTIONS } from '@shared/apis/timetable/festival-timetable-queries';
 import { routePath } from '@shared/router/path';
 import { FestivalTimetable } from '@shared/types/festival-timetable-response';
 
@@ -21,8 +23,14 @@ const FestivalSelector = ({
 }: Props) => {
   const navigate = useNavigate();
 
+  const { data } = useSuspenseInfiniteQuery(
+    FESTIVAL_TIMETABLE_QUERY_OPTIONS.ADDABLE_FESTIVALS(),
+  );
+
+  const isEmpty = data.pages[0]?.festivals.length === 0;
+
   const handleAddFestival = () => {
-    navigate(`${routePath.ADD_FESTIVAL}`);
+    navigate(isEmpty ? routePath.NO_UPCOMING_FESTIVAL : routePath.ADD_FESTIVAL);
   };
 
   const handleDeleteFestival = () => {

--- a/apps/client/src/shared/router/routes/timetable-routes.tsx
+++ b/apps/client/src/shared/router/routes/timetable-routes.tsx
@@ -2,7 +2,11 @@ import RequireLoginPage from '@pages/auth/page/require-login';
 import TimetableLayout from '@pages/timetable/page/timetable-layout';
 import TimeTablePage from '@pages/timetable/page/timetable-page';
 
-import { AddFestivalPage, DeleteFestivalPage } from '../lazy';
+import {
+  AddFestivalPage,
+  DeleteFestivalPage,
+  NoUpcomingFestival,
+} from '../lazy';
 import { routePath } from '../path';
 import { createProtectedRoute } from '../protected-route';
 
@@ -26,6 +30,10 @@ export const timetableRoutes = [
       {
         path: routePath.DELETE_FESTIVAL,
         element: createProtectedRoute(true, <DeleteFestivalPage />),
+      },
+      {
+        path: routePath.NO_UPCOMING_FESTIVAL,
+        element: createProtectedRoute(true, <NoUpcomingFestival />),
       },
     ],
   },


### PR DESCRIPTION
## 📌 Summary

> - #606 

추가할 페스티벌이 없을 때를 대비하여 해당 페이지의 라우터를 추가하고,
"페스티벌 추가하기" 클릭 시 조건에 따라 분기 처리합니다.

## 📚 Tasks

- 추가할 페스티벌 없을 경우 보여줄 페이지 라우터 등록
- "페스티벌 추가하기" 클릭 시 조건 분기 처리

## 👀 To Reviewer

페스티벌이 하나 이상 이미 추가된 상태에서도 드롭다운 메뉴 내 "페스티벌 추가하기" 버튼을 클릭했을 때
추가 가능한 페스티벌이 없으면 해당 안내 페이지로 이동하도록 처리했습니다~!

## 📸 Screenshot

<img width="390" alt="스크린샷 2025-06-16 오전 1 18 46" src="https://github.com/user-attachments/assets/9dec29a5-d308-48d6-b74d-82be1c050ad3" />
