### PR TITLE
Feat(client): 홈페이지 Chip 카테고리 상단 고정

### DIFF
--- a/apps/client/src/pages/home/components/category-tabs.css.ts
+++ b/apps/client/src/pages/home/components/category-tabs.css.ts
@@ -1,5 +1,14 @@
 import { style } from '@vanilla-extract/css';
 
+import { themeVars } from '@confeti/design-system/styles';
+
+export const container = style({
+  position: 'sticky',
+  top: themeVars.size.height.header,
+  zIndex: themeVars.zIndex.header.content,
+  background: themeVars.color.white,
+});
+
 export const chipList = style({
   display: 'flex',
   gap: '0.8rem',

--- a/apps/client/src/pages/home/components/category-tabs.tsx
+++ b/apps/client/src/pages/home/components/category-tabs.tsx
@@ -1,37 +1,30 @@
-import { useState } from 'react';
-
 import { Chip } from '@confeti/design-system';
+
+import { HOME_CATEGORY_TAB } from '../constants/tab';
 
 import * as styles from './category-tabs.css';
 
-const CategoryTabs = ({
-  scrollHandlers,
-}: {
-  scrollHandlers: {
-    ticketing: () => void;
-    suggestPerformance: () => void;
-    suggestMusic: () => void;
-  };
-}) => {
+interface Props {
+  selectedCategory: HOME_CATEGORY_TAB;
+  onCategoryClick: (category: HOME_CATEGORY_TAB) => void;
+}
+
+const CategoryTabs = ({ selectedCategory, onCategoryClick }: Props) => {
   const categories = [
-    { label: '티켓 오픈', onClick: scrollHandlers.ticketing },
-    { label: '추천 공연', onClick: scrollHandlers.suggestPerformance },
-    { label: '플레이리스트', onClick: scrollHandlers.suggestMusic },
+    HOME_CATEGORY_TAB.TICKETING,
+    HOME_CATEGORY_TAB.SUGGEST_PERFORMANCE,
+    HOME_CATEGORY_TAB.PLAYLIST,
   ];
-  const [selectedCategory, setSelectedCategory] = useState('티켓 오픈');
 
   return (
-    <nav>
+    <nav className={styles.container}>
       <ul className={styles.chipList}>
-        {categories.map(({ label, onClick }) => (
+        {categories.map((label) => (
           <li key={label}>
             <Chip
               label={label}
               variant={selectedCategory === label ? 'active' : 'default'}
-              onClick={() => {
-                setSelectedCategory(label);
-                onClick();
-              }}
+              onClick={() => onCategoryClick(label)}
             />
           </li>
         ))}

--- a/apps/client/src/pages/home/constants/menu.ts
+++ b/apps/client/src/pages/home/constants/menu.ts
@@ -1,5 +1,0 @@
-export enum TAB_MENU {
-  HOME = 0,
-  TIMETABLE = 1,
-  MY_HISTORY = 2,
-}

--- a/apps/client/src/pages/home/constants/tab.ts
+++ b/apps/client/src/pages/home/constants/tab.ts
@@ -1,0 +1,11 @@
+export enum TAB_MENU {
+  HOME = 0,
+  TIMETABLE = 1,
+  MY_HISTORY = 2,
+}
+
+export const enum HOME_CATEGORY_TAB {
+  TICKETING = '티켓 오픈',
+  SUGGEST_PERFORMANCE = '추천 공연',
+  PLAYLIST = '플레이리스트',
+}

--- a/apps/client/src/pages/home/hooks/use-active-section.ts
+++ b/apps/client/src/pages/home/hooks/use-active-section.ts
@@ -27,20 +27,19 @@ export const useActiveSection = (scrollRefs: ScrollRefs) => {
     if (isScrollingByClick) return;
 
     const onScroll = () => {
-      const scrollY = window.scrollY || window.pageYOffset;
+      const scrollY = window.scrollY;
 
       const suggestPerformanceTop =
         scrollRefs.suggestPerformance.element.current?.offsetTop || 0;
       const suggestMusicTop =
         scrollRefs.suggestMusic.element.current?.offsetTop || 0;
-
-      console.log(suggestPerformanceTop, suggestMusicTop, scrollY);
+      const viewportMiddle = window.innerHeight / 2;
 
       switch (true) {
-        case scrollY >= suggestMusicTop - 450:
+        case scrollY >= suggestMusicTop - viewportMiddle:
           setCurrentCategory(HOME_CATEGORY_TAB.PLAYLIST);
           break;
-        case scrollY >= suggestPerformanceTop - 400:
+        case scrollY >= suggestPerformanceTop - viewportMiddle:
           setCurrentCategory(HOME_CATEGORY_TAB.SUGGEST_PERFORMANCE);
           break;
         default:

--- a/apps/client/src/pages/home/hooks/use-active-section.ts
+++ b/apps/client/src/pages/home/hooks/use-active-section.ts
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+
+import { HOME_CATEGORY_TAB } from '../constants/tab';
+
+interface ScrollRefs {
+  ticketing: {
+    element: React.RefObject<HTMLElement | null>;
+    onMoveToElement: () => void;
+  };
+  suggestPerformance: {
+    element: React.RefObject<HTMLElement | null>;
+    onMoveToElement: () => void;
+  };
+  suggestMusic: {
+    element: React.RefObject<HTMLElement | null>;
+    onMoveToElement: () => void;
+  };
+}
+
+export const useActiveSection = (scrollRefs: ScrollRefs) => {
+  const [currentCategory, setCurrentCategory] = useState<HOME_CATEGORY_TAB>(
+    HOME_CATEGORY_TAB.TICKETING,
+  );
+  const [isScrollingByClick, setIsScrollingByClick] = useState(false);
+
+  useEffect(() => {
+    if (isScrollingByClick) return;
+
+    const onScroll = () => {
+      const scrollY = window.scrollY || window.pageYOffset;
+
+      const suggestPerformanceTop =
+        scrollRefs.suggestPerformance.element.current?.offsetTop || 0;
+      const suggestMusicTop =
+        scrollRefs.suggestMusic.element.current?.offsetTop || 0;
+
+      console.log(suggestPerformanceTop, suggestMusicTop, scrollY);
+
+      switch (true) {
+        case scrollY >= suggestMusicTop - 450:
+          setCurrentCategory(HOME_CATEGORY_TAB.PLAYLIST);
+          break;
+        case scrollY >= suggestPerformanceTop - 400:
+          setCurrentCategory(HOME_CATEGORY_TAB.SUGGEST_PERFORMANCE);
+          break;
+        default:
+          setCurrentCategory(HOME_CATEGORY_TAB.TICKETING);
+          break;
+      }
+    };
+
+    window.addEventListener('scroll', onScroll);
+
+    return () => window.removeEventListener('scroll', onScroll);
+  }, [scrollRefs, isScrollingByClick]);
+
+  const handleCategoryClick = (category: HOME_CATEGORY_TAB) => {
+    setCurrentCategory(category);
+    setIsScrollingByClick(true);
+
+    switch (category) {
+      case HOME_CATEGORY_TAB.TICKETING:
+        scrollRefs.ticketing.onMoveToElement();
+        break;
+      case HOME_CATEGORY_TAB.SUGGEST_PERFORMANCE:
+        scrollRefs.suggestPerformance.onMoveToElement();
+        break;
+      case HOME_CATEGORY_TAB.PLAYLIST:
+        scrollRefs.suggestMusic.onMoveToElement();
+        break;
+      default:
+        scrollRefs.ticketing.onMoveToElement();
+        break;
+    }
+
+    setTimeout(() => {
+      setIsScrollingByClick(false);
+    }, 500);
+  };
+
+  return { currentCategory, handleCategoryClick };
+};

--- a/apps/client/src/pages/home/page/home-page.tsx
+++ b/apps/client/src/pages/home/page/home-page.tsx
@@ -11,7 +11,8 @@ import PerformanceCarouselSection from '../components/performance-carousel-secti
 import SuggestMusicSection from '../components/suggest-music-section';
 import SuggestPerformanceSection from '../components/suggest-performance-section';
 import TicketingSection from '../components/ticketing-section';
-import { TAB_MENU } from '../constants/menu';
+import { TAB_MENU } from '../constants/tab';
+import { useActiveSection } from '../hooks/use-active-section';
 import { useHomeQueries } from '../hooks/use-home-queries';
 
 const HomePage = () => {
@@ -20,6 +21,7 @@ const HomePage = () => {
     suggestPerformance: useMoveScroll(),
     suggestMusic: useMoveScroll(),
   };
+  const { currentCategory, handleCategoryClick } = useActiveSection(scrollRefs);
   const { isButtonHidden } = useScrollPosition();
 
   const {
@@ -37,11 +39,8 @@ const HomePage = () => {
       <Spacing size="xl" color="white" />
 
       <CategoryTabs
-        scrollHandlers={{
-          ticketing: scrollRefs.ticketing.onMoveToElement,
-          suggestPerformance: scrollRefs.suggestPerformance.onMoveToElement,
-          suggestMusic: scrollRefs.suggestMusic.onMoveToElement,
-        }}
+        selectedCategory={currentCategory}
+        onCategoryClick={handleCategoryClick}
       />
       <Spacing size="lg" color="white" />
 
@@ -50,6 +49,7 @@ const HomePage = () => {
         data={ticketing.performances}
         userName={userName}
       />
+
       <Spacing size="2xl" color="white" />
 
       <SuggestPerformanceSection
@@ -63,8 +63,8 @@ const HomePage = () => {
         data={suggestMusicPerformance}
       />
       <Spacing size="2xl" color="white" />
-      <FloatingButton isButtonHidden={isButtonHidden} />
 
+      <FloatingButton isButtonHidden={isButtonHidden} />
       <Footer />
     </>
   );

--- a/apps/client/src/pages/my-history/page/my-history.tsx
+++ b/apps/client/src/pages/my-history/page/my-history.tsx
@@ -3,7 +3,7 @@ import { Outlet, useLocation } from 'react-router-dom';
 import NavigationTabs from '@shared/components/navigation-tabs';
 import { routePath } from '@shared/router/path';
 
-import { TAB_MENU } from '@pages/home/constants/menu';
+import { TAB_MENU } from '@pages/home/constants/tab';
 
 const MyHistoryPage = () => {
   const location = useLocation();

--- a/apps/client/src/pages/my/page/setting/setting.css.ts
+++ b/apps/client/src/pages/my/page/setting/setting.css.ts
@@ -5,7 +5,7 @@ import { themeVars } from '@confeti/design-system/styles';
 export const pageWrapper = style({
   display: 'flex',
   flexDirection: 'column',
-  minHeight: 'calc(100vh - 5.4rem)',
+  minHeight: `calc(100vh - ${themeVars.size.height.header})`,
 });
 
 export const contentsSection = style({

--- a/apps/client/src/pages/onboarding/components/artist-select.css.ts
+++ b/apps/client/src/pages/onboarding/components/artist-select.css.ts
@@ -8,7 +8,7 @@ const fadeInScale = keyframes({
 });
 
 export const onboardingContentSection = style({
-  height: 'calc(100dvh - 5.4rem)',
+  height: `calc(100dvh - ${themeVars.size.height.header})`,
   padding: '2rem',
   display: 'flex',
   flexDirection: 'column',

--- a/apps/client/src/pages/onboarding/components/onboarding-complete.css.ts
+++ b/apps/client/src/pages/onboarding/components/onboarding-complete.css.ts
@@ -7,7 +7,7 @@ export const completeContentSection = recipe({
   base: {
     ...themeVars.display.flexColumn,
     width: '100%',
-    height: 'calc(100dvh - 5.4rem)',
+    height: `calc(100dvh - ${themeVars.size.height.header})`,
   },
   variants: {
     phase: {

--- a/apps/client/src/pages/timetable/page/timetable-layout.tsx
+++ b/apps/client/src/pages/timetable/page/timetable-layout.tsx
@@ -3,7 +3,7 @@ import { Outlet, useLocation } from 'react-router-dom';
 import NavigationTabs from '@shared/components/navigation-tabs';
 import { routePath } from '@shared/router/path';
 
-import { TAB_MENU } from '@pages/home/constants/menu';
+import { TAB_MENU } from '@pages/home/constants/tab';
 
 const TimetableLayout = () => {
   const location = useLocation();

--- a/apps/client/src/shared/components/navigation-tabs.tsx
+++ b/apps/client/src/shared/components/navigation-tabs.tsx
@@ -4,7 +4,7 @@ import { Navigation } from '@confeti/design-system';
 
 import { routePath } from '@shared/router/path';
 
-import { TAB_MENU } from '@pages/home/constants/menu';
+import { TAB_MENU } from '@pages/home/constants/tab';
 
 interface Props {
   defaultActiveTab: TAB_MENU;

--- a/packages/design-system/src/components/header/header.css.ts
+++ b/packages/design-system/src/components/header/header.css.ts
@@ -12,7 +12,7 @@ export const container = recipe({
   variants: {
     variant: {
       default: {
-        height: '5.4rem',
+        height: themeVars.size.height.header,
         position: 'sticky',
         left: 0,
         top: 0,

--- a/packages/design-system/src/styles/theme.css.ts
+++ b/packages/design-system/src/styles/theme.css.ts
@@ -7,18 +7,20 @@ import { color } from './tokens/color';
 import { display } from './tokens/display';
 import { fontStyles } from './tokens/font-styles';
 import { overlay } from './tokens/overlay';
+import { size } from './tokens/size';
 import { typography } from './tokens/typography';
 import { zIndex } from './tokens/z-index';
 
 const tokens = {
   color: color,
   fontStyles: fontStyles,
-  zIndex: zIndex,
   display: display,
   border: border,
   overlay: overlay,
-  ...typography,
+  size: size,
+  zIndex: zIndex,
   shadowStyles,
+  ...typography,
 };
 
 const properties = defineProperties({

--- a/packages/design-system/src/styles/tokens/size.ts
+++ b/packages/design-system/src/styles/tokens/size.ts
@@ -1,0 +1,5 @@
+export const size = {
+  height: {
+    header: '5.4rem',
+  },
+} as const;


### PR DESCRIPTION
## 📌 Summary

> - #609 

홈페이지 내 Chip 카테고리를 스크롤에 따라 상단에 고정했어요.

## 📚 Tasks

- 스크롤에 따라 Chip 컴포넌트 상단 고정
- size 디자인 토큰 추가

## 👀 To Reviewer

### size 디자인 토큰 추가

많은 css 파일에서 헤더 높이를 계산해서 스타일링을 하는 경우가 많더라구요 (5.4rem)
css내 의미를 알 수 없는 숫자들도 매직넘버와 같은 문제점을 가지고 있다 생각했어요.
추후에 헤더 크기가 바뀐다거나 하면 모든 파일에서 찾아 수정해야 하는 일이 발생할 수 있기에 디자인 토큰으로 지정해두었어요.
앞으로 재사용될 size(width, height, ..)는 디자인 토큰에 지정해주세요!


## 📸 Screenshot


https://github.com/user-attachments/assets/a57f9609-a79c-4364-bae7-df2c801463b2


