### PR TITLE
Refactor(client): 토큰 재발급 로직 수정

### DIFF
--- a/apps/client/src/pages/onboarding/hooks/use-onboard-mutation.ts
+++ b/apps/client/src/pages/onboarding/hooks/use-onboard-mutation.ts
@@ -1,5 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 
+import { authTokenHandler, getRefreshToken } from '@confeti/core/auth';
 import { BaseResponse } from '@confeti/core/http';
 
 import { postReissueToken } from '@shared/apis/auth/auth-mutation';
@@ -29,7 +30,8 @@ export const usePostAuthOnboarding = () => {
       }
 
       try {
-        await postReissueToken();
+        const { data } = await postReissueToken(getRefreshToken());
+        authTokenHandler('set', data.accessToken, data.refreshToken);
       } catch (error) {
         console.log('error', error);
       }

--- a/apps/client/src/shared/apis/auth/auth-mutation.ts
+++ b/apps/client/src/shared/apis/auth/auth-mutation.ts
@@ -1,10 +1,6 @@
-import {
-  authTokenHandler,
-  getRefreshToken,
-  TokenResponse,
-} from '@confeti/core/auth';
+import { TokenResponse } from '@confeti/core/auth';
 import { createInstance } from '@confeti/core/http';
-import { BaseResponse, HTTP_STATUS_CODE, HTTPError } from '@confeti/core/http';
+import { BaseResponse } from '@confeti/core/http';
 
 import { END_POINT } from '@shared/constants/api';
 import { ENV_CONFIG } from '@shared/constants/config';

--- a/apps/client/src/shared/constants/api.ts
+++ b/apps/client/src/shared/constants/api.ts
@@ -85,7 +85,7 @@ export const END_POINT = {
   //로그인,로그아웃,토큰재발급
   POST_SOCIAL_LOGIN: '/auth/login',
   POST_LOGOUT: '/auth/logout',
-  POST_REISSUE_TOKEN: 'auth/reissue',
+  POST_REISSUE_TOKEN: '/auth/reissue',
   DELETE_ACCOUNT: '/auth/withdraw',
 
   //온보딩


### PR DESCRIPTION
## 📌 Summary

> - #646 

## 📚 Tasks

- 온보딩 후 토큰 재발급 로직 수정 


## 👀 To Reviewer

c0a15ca5c9b00d61cb8069b21bc788f70116ead7 급하게 개발하느랴 바로 develop에 넣었는데 해당 부분 수정해서 다시 올려요.

```ts
// 기존 구현 방식

export const postReissueToken = async (): Promise<void> => {
  const refreshToken = getRefreshToken();

  try {
    const response = await authPost<BaseResponse<TokenResponse>>(
      END_POINT.POST_REISSUE_TOKEN,
      {},
      { headers: { Authorization: `Bearer ${refreshToken}` } },
    );

    const { accessToken, refreshToken: newRefreshToken } = response.data;
    authTokenHandler('set', accessToken, newRefreshToken);
  } catch (error) {
    if (error instanceof HTTPError) {
      throw error;
    }
    throw new HTTPError(
      HTTP_STATUS_CODE.UNAUTHORIZED,
      '토큰 재발급에 실패했습니다.',
    );
  }
};

```
기존 작업했던 방식에서는 postReissueToken이 많은 역할을 담당하고 있다고 판단해서 SRP 원칙에 따라 역할을 분리시켰어요.

```ts
// 수정 방식
export const postReissueToken = async (
  refreshToken: string | null,
): Promise<BaseResponse<TokenResponse>> => {
  return await authPost<BaseResponse<TokenResponse>>(
    END_POINT.POST_REISSUE_TOKEN,
    {},
    { headers: { Authorization: `Bearer ${refreshToken}` } },
  );
};

// 사용할 때
export const usePostAuthOnboarding = () => {
  return useMutation({
    mutationFn: async (favoriteArtists: string[]) => {
      try {
        await postAuthOnboarding(favoriteArtists);
      } catch (error) {
        console.log('error', error);
      }

      try {
        const { data } = await postReissueToken(getRefreshToken());
        authTokenHandler('set', data.accessToken, data.refreshToken);
      } catch (error) {
        console.log('error', error);
      }
    },
  });
};
```

근데 결국에는 postReissueToken을 사용하는 훅인 `usePostAuthOnboarding` 에서도 토큰을 가져오고 저장하는 로직이 포함되다보니... SRP 원칙에 따라 분리한게 맞나? 라는 생각이 들어요. 추후에 postReissueToken함수를 사용해야하는 부분이 생긴다면 보일러플레이트가 생길수도있구요.

그렇다고 또 해당 부분만 따로 함수로 분리하자니...
```ts
export const reissueAndSaveToken = async () => {
  const { data } = await postReissueToken(getRefreshToken());
  authTokenHandler('set', data.accessToken, data.refreshToken);
};

export const usePostAuthOnboarding = () => {
  return useMutation({
    mutationFn: async (favoriteArtists: string[]) => {
      await postAuthOnboarding(favoriteArtists);
      await reissueAndSaveToken();
    },
  });
};
```
너무 오버엔지니어링이 아닐까? 고민에 빠졌습니다... 의견이 궁금해요.