### PR TITLE
Feat(client): 온보딩 페이지 에러바운더리 분리

### DIFF
--- a/apps/client/src/shared/router/routes/layout-free-routes.tsx
+++ b/apps/client/src/shared/router/routes/layout-free-routes.tsx
@@ -1,5 +1,7 @@
 import * as Sentry from '@sentry/react';
 
+import ErrorFallback from '@shared/pages/error/error';
+
 import { OnboardingPage } from '../lazy';
 import { createOnboardingGuard } from '../onboarding-guard';
 import { routePath } from '../path';
@@ -8,7 +10,7 @@ export const layoutFreeRoutes = [
   {
     path: routePath.ONBOARDING,
     element: (
-      <Sentry.ErrorBoundary fallback={<OnboardingPage />}>
+      <Sentry.ErrorBoundary fallback={ErrorFallback}>
         {createOnboardingGuard(<OnboardingPage />)}
       </Sentry.ErrorBoundary>
     ),

--- a/apps/client/src/shared/router/routes/layout-free-routes.tsx
+++ b/apps/client/src/shared/router/routes/layout-free-routes.tsx
@@ -1,3 +1,5 @@
+import * as Sentry from '@sentry/react';
+
 import { OnboardingPage } from '../lazy';
 import { createOnboardingGuard } from '../onboarding-guard';
 import { routePath } from '../path';
@@ -5,6 +7,10 @@ import { routePath } from '../path';
 export const layoutFreeRoutes = [
   {
     path: routePath.ONBOARDING,
-    element: createOnboardingGuard(<OnboardingPage />),
+    element: (
+      <Sentry.ErrorBoundary fallback={<OnboardingPage />}>
+        {createOnboardingGuard(<OnboardingPage />)}
+      </Sentry.ErrorBoundary>
+    ),
   },
 ];


### PR DESCRIPTION
## 📌 Summary

- #651 

## 📚 Tasks

-  온보딩 에러바운더리 분리
## 👀 To Reviewer

온보딩 페이지의 에러바운더리를 별도로 분리했어요. 온보딩 과정 중 에러가 발생했을 때, home 이 아닌 onboarding 으로 리다이렉트 되도록 설정했어요.

기존 에러바운더리를 유지할 경우 에러가 발생했을 때 일반 유저가 다시 onboarding 으로 접근할 진입점이 존재하지 않기에.  리다이렉트 url 을 재설정 할 수 있도록했어요

https://weareconfeti.slack.com/archives/C08JX8QTCCR/p1755310274455629


<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요. 필요시 .gif 형식으로 첨부해주세요.
-->
