### PR TITLE
Refactor(client): 프로필 편집 페이지 개선

### DIFF
--- a/apps/client/src/pages/my/hooks/use-edit-profile.ts
+++ b/apps/client/src/pages/my/hooks/use-edit-profile.ts
@@ -1,0 +1,54 @@
+import { useReducer, useRef } from 'react';
+
+type State = {
+  name: string;
+  profileFile: File | null;
+  previewImgUrl: string;
+};
+
+type Action =
+  | { type: 'SET_NAME'; payload: string }
+  | { type: 'SET_PROFILE_FILE'; payload: File }
+  | { type: 'SET_PREVIEW_URL'; payload: string };
+
+const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case 'SET_NAME':
+      return { ...state, name: action.payload };
+    case 'SET_PROFILE_FILE':
+      return { ...state, profileFile: action.payload };
+    case 'SET_PREVIEW_URL':
+      return { ...state, previewImgUrl: action.payload };
+    default:
+      return state;
+  }
+};
+
+export const useEditProfile = (initialUrl: string) => {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [state, dispatch] = useReducer(reducer, {
+    name: '',
+    profileFile: null,
+    previewImgUrl: initialUrl,
+  });
+
+  const triggerFileInput = () => fileInputRef.current?.click();
+
+  const handleInputChange = (value: string) => {
+    dispatch({ type: 'SET_NAME', payload: value });
+  };
+
+  const handleFileChange = (file?: File) => {
+    if (!file) return;
+    dispatch({ type: 'SET_PROFILE_FILE', payload: file });
+    dispatch({ type: 'SET_PREVIEW_URL', payload: URL.createObjectURL(file) });
+  };
+
+  return {
+    state,
+    fileInputRef,
+    triggerFileInput,
+    handleInputChange,
+    handleFileChange,
+  };
+};

--- a/apps/client/src/pages/my/page/edit/edit-profile.tsx
+++ b/apps/client/src/pages/my/page/edit/edit-profile.tsx
@@ -83,14 +83,17 @@ const EditProfile = () => {
     fileInputRef.current?.click();
   };
 
-  const handleSave = async () => {
+  const handleSave = () => {
     const newName = name || profileData.name;
 
-    const payload = profileFile
-      ? { name: newName, profileFile }
-      : { name: newName, profileUrl: profileData.profileUrl };
+    const formData = new FormData();
+    formData.append('name', newName);
 
-    mutate(payload);
+    if (profileFile) {
+      formData.append('profileFile', profileFile);
+    }
+
+    mutate(formData);
   };
 
   return (

--- a/apps/client/src/shared/apis/user/user-mutations.ts
+++ b/apps/client/src/shared/apis/user/user-mutations.ts
@@ -12,21 +12,11 @@ export const USER_MUTATION_OPTIONS = {
   PATCH_PROFILE: () =>
     mutationOptions({
       mutationKey: USER_MUTATION_KEY.PATCH_PROFILE(),
-      mutationFn: (userInfo: UserInfo) => patchUserInfo(userInfo),
+      mutationFn: (formData: FormData) => patchUserInfo(formData),
     }),
 };
 
-export const patchUserInfo = async (userInfo: UserInfo): Promise<UserInfo> => {
-  const formData = new FormData();
-  formData.append('name', userInfo.name);
-
-  if (userInfo.profileFile) {
-    formData.append('profileFile', userInfo.profileFile);
-  } else {
-    const emptyFile = new Blob([], { type: 'image/jpeg' });
-    formData.append('profileFile', emptyFile, 'empty.jpg');
-  }
-
+export const patchUserInfo = async (formData: FormData): Promise<UserInfo> => {
   const response = await patch<BaseResponse<UserInfo>>(
     END_POINT.PATCH_USER_INFO,
     formData,


### PR DESCRIPTION
## 📌 Summary

> - #654 

프로필 편집 페이지 로직을 개선했어요.

## 📚 Tasks

- 프로필 사진 변경없이 요청을 보내는 경우 이미지가 사라지던 버그 해결
- useEditProfile커스텀 훅 제작
- API 레이어(페칭함수-patchUserInfo)내 FormData생성 로직 분리

## 👀 To Reviewer

기존에는 업로드할 파일(이미지), 기존 이미지, 이름 등 복잡한 상태관리를 여러개의 state로 관리하고 있었는데,
이를 useReducer로 통합했어요. 가독성 측면에서 더 괜찮은 방법이라고 생각했어요.

