### PR TITLE
Feat(client): 에러 바운더리 resetKey 지정

### DIFF
--- a/apps/client/src/shared/pages/error/error.tsx
+++ b/apps/client/src/shared/pages/error/error.tsx
@@ -18,7 +18,6 @@ const Error = () => {
   const navigate = useNavigate();
   const handleNavigate = () => {
     navigate('/');
-    window.location.reload();
   };
 
   return (

--- a/apps/client/src/shared/router/global-layout.tsx
+++ b/apps/client/src/shared/router/global-layout.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react';
-import * as Sentry from '@sentry/react';
-import { Outlet } from 'react-router-dom';
+import { ErrorBoundary } from 'react-error-boundary';
+import { Outlet, useLocation } from 'react-router-dom';
 
 import { Header } from '@shared/components';
 import ErrorFallback from '@shared/pages/error/error';
@@ -9,14 +9,19 @@ import Loading from '@shared/pages/loading/loading';
 import ScrollToTop from './scroll-to-top';
 
 export default function GlobalLayout() {
+  const location = useLocation();
+
   return (
     <ScrollToTop>
       <Header />
-      <Sentry.ErrorBoundary fallback={ErrorFallback}>
+      <ErrorBoundary
+        fallback={<ErrorFallback />}
+        resetKeys={[location.pathname]}
+      >
         <Suspense fallback={<Loading />}>
           <Outlet />
         </Suspense>
-      </Sentry.ErrorBoundary>
+      </ErrorBoundary>
     </ScrollToTop>
   );
 }


### PR DESCRIPTION
## 📌 Summary

- #663 

## 📚 Tasks

- 에러 바운더리의 resetKey 를 지정해서 기존 window.location.relaod() 문제를 해결해요

## 👀 To Reviewer

아래 영상(기존)처럼 에러바운더리에 걸려서, 에러 페이지가 fallback 되었을 때, navigation 에 존재하는 로고 클릭으로 home page 전환이 되지 않는 상태였어요. 이유는 한번 에러가 발생하면 ErrorBoundary 는 트리 전체를 잡고있기때문에 해당 컴포넌트 트리 아래는 "깨진 상태로 고정" 되고, 헤더에 존재하는 ReactRouter의 navigate 는 location 만 변경하지, ErrorBoundary 내부 상태를 리셋하지는 않아서 발생하는거에요 
따라서 `window.location.reload();` 로 리액트 앱 전체를 다시 마운트하면서 ErrorBoundary 도 초기화해주고 있던게 기존이었고, 그 문제를 지금 pr에서 해결했어요.

---

```typescript
      <Sentry.ErrorBoundary fallback={ErrorFallback} key={location.pathname}>
```

처음에는 이런 방식으로 key 값이 바뀔때마다 에러 바운더리 컴포넌트를 완전히 새로 언마운트 -> 마운트 하도록 했는데, pathName이 변경될 때마다 에러 바운더리 전체가 새로 마운트 되는 것이 성능상 문제가 생길까 우려되었어요. 

하지만 실제로 부담이 크진 않아요. ErrorBoundary 자체가 굉장히 얇은 레이어로 구성되어있고, 어차피 Route 전환 자체가 children 트리 전체를 리렌더하기에 오히려 에러 바운더리만 새롭게 마운트 되지 않는 것이 어색하다고 볼 수도 있구요. 

근데 그 문제를 벗어나서 기존 목표는 navigate 로 `에러 상태` 를 초기화 하는 것이기에 `resetKeys` (배열 안에 값이 변경되면 Errorboundary의 `에러 상태` 만 초기화함) 를 지정해두어서 pathName이 변경될 때마다 컴포넌트 전체가 아닌 에러 상태만을 초기화 하도록 설정했어요
## 📸 Screenshot

### 변경 후
https://github.com/user-attachments/assets/394c036e-5ab3-4e41-bf56-7065a0f2fbf7


### 기존 
https://github.com/user-attachments/assets/fd95e793-b395-4428-bf64-4fe7c0a77a5c


