### PR TITLE
UX/UI(Client): 공연 상세 아티스트 더보기 레이아웃 시프트 개선

### DIFF
--- a/apps/client/src/pages/performance/components/artist/festival-artist-section.css.ts
+++ b/apps/client/src/pages/performance/components/artist/festival-artist-section.css.ts
@@ -1,5 +1,4 @@
 import { style } from '@vanilla-extract/css';
-import { recipe } from '@vanilla-extract/recipes';
 
 import { themeVars } from '@confeti/design-system/styles';
 
@@ -33,25 +32,22 @@ export const festivalDayBadge = style({
   marginTop: '2rem',
 });
 
-export const artistGridVariants = recipe({
-  base: {
-    width: '100%',
-    display: 'grid',
-    gridTemplateColumns: 'repeat(4, 1fr)',
-    gap: '1.6rem',
-    overflow: 'hidden',
-    transition: 'max-height 0.4s ease',
-  },
-  variants: {
-    expanded: {
-      true: {
-        maxHeight: '100rem',
-      },
-      false: {
-        maxHeight: '10.5rem',
-      },
-    },
-  },
+export const artistGrid = style({
+  width: '100%',
+  display: 'grid',
+  gridTemplateColumns: 'repeat(4, 1fr)',
+  gap: '1.6rem',
+});
+
+export const artistList = style({
+  ...themeVars.display.flexColumn,
+  width: '100%',
+  gap: '1.6rem',
+});
+
+export const expandedArtistGrid = style({
+  width: '100%',
+  overflow: 'hidden',
 });
 
 export const festivalArtistContainer = style({

--- a/apps/client/src/pages/performance/components/artist/festival-artist-section.css.ts
+++ b/apps/client/src/pages/performance/components/artist/festival-artist-section.css.ts
@@ -42,12 +42,15 @@ export const artistGrid = style({
 export const artistList = style({
   ...themeVars.display.flexColumn,
   width: '100%',
-  gap: '1.6rem',
 });
 
-export const expandedArtistGrid = style({
+export const artistCollapseRegion = style({
   width: '100%',
   overflow: 'hidden',
+});
+
+export const artistCollapseRegionInner = style({
+  paddingTop: '1.6rem',
 });
 
 export const festivalArtistContainer = style({

--- a/apps/client/src/pages/performance/components/artist/festival-artist-section.tsx
+++ b/apps/client/src/pages/performance/components/artist/festival-artist-section.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
+import { AnimatePresence, motion } from 'motion/react';
 
 import { Avatar } from '@confeti/design-system';
-import { cn } from '@confeti/utils';
 
 import { logClickEvent } from '@shared/analytics/logging';
+import { drop, isEmpty, take } from '@shared/lib/es-toolkit/es';
 import { FestivalDate } from '@shared/types/festival-response';
 
 import MoreButton from '../button/more-button';
@@ -12,85 +13,105 @@ import ArtistSectionTitle from './artist-section-title';
 import * as styles from './festival-artist-section.css';
 
 const MAX_ARTIST_LENGTH = 4;
+const ARTIST_EXPAND_TRANSITION = {
+  duration: 0.35,
+  ease: 'easeOut',
+} as const;
 
-interface FestivalArtistSectionProps {
-  artists: FestivalDate[];
-}
+const FestivalArtistDateSection = ({
+  festivalDate,
+}: {
+  festivalDate: FestivalDate;
+}) => {
+  const [showExpandedArtists, setShowExpandedArtists] = useState(false);
+  const hiddenArtists = drop(festivalDate.artists, MAX_ARTIST_LENGTH);
 
-const FestivalArtistSection = ({ artists }: FestivalArtistSectionProps) => {
-  const [expandedDates, setExpandedDates] = useState<Record<number, boolean>>(
-    {},
-  );
-
-  const toggleExpanded = (id: number) => {
+  const handleToggleExpandedArtists = () => {
     logClickEvent({
       name: 'click_box_show_more',
       params: {
         section: 'festival_artist',
       },
     });
-    setExpandedDates((prev) => ({
-      ...prev,
-      [id]: !prev[id],
-    }));
+    setShowExpandedArtists((prev) => !prev);
   };
 
-  const processedArtists = artists.map((festivalDate) => {
-    const isExpanded = Boolean(expandedDates[festivalDate.festivalDateId]);
-    const isMorebuttonVisible = festivalDate.artists.length > MAX_ARTIST_LENGTH;
-    return {
-      ...festivalDate,
-      isExpanded,
-      isMorebuttonVisible,
-    };
-  });
-
   return (
-    <>
-      <div className={styles.festivalArtistTitle}>
-        <ArtistSectionTitle />
-      </div>
-      <section className={styles.festivalContentContainer}>
-        {processedArtists.map((festivalDate) => (
-          <div
-            key={festivalDate.festivalDateId}
-            className={styles.festivalContentItems}
-          >
-            <p className={styles.festivalDayBadge}>{festivalDate.festivalAt}</p>
-            <div
-              className={cn(
-                styles.artistGridVariants({
-                  expanded: festivalDate.isExpanded,
-                }),
-              )}
+    <div className={styles.festivalContentItems}>
+      <p className={styles.festivalDayBadge}>{festivalDate.festivalAt}</p>
+      <div className={styles.artistList}>
+        <div className={styles.artistGrid}>
+          {take(festivalDate.artists, MAX_ARTIST_LENGTH).map((artist) => (
+            <figure
+              key={artist.artistId}
+              className={styles.festivalArtistContainer}
             >
-              {festivalDate.artists.map((artist) => (
-                <figure
-                  key={artist.artistId}
-                  className={styles.festivalArtistContainer}
-                >
-                  <Avatar
-                    size="lg"
-                    src={artist.profileUrl}
-                    isHandleClick={false}
-                  />
-                  <p className={styles.festivalArtistName}>{artist.name}</p>
-                </figure>
-              ))}
-            </div>
-            {festivalDate.isMorebuttonVisible && (
-              <div className={styles.festivalMorebutton}>
-                <MoreButton
-                  isExpanded={festivalDate.isExpanded}
-                  onToggle={() => toggleExpanded(festivalDate.festivalDateId)}
-                />
+              <Avatar size="lg" src={artist.profileUrl} isHandleClick={false} />
+              <p className={styles.festivalArtistName}>{artist.name}</p>
+            </figure>
+          ))}
+        </div>
+        <AnimatePresence initial={false}>
+          {showExpandedArtists && (
+            <motion.div
+              className={styles.expandedArtistGrid}
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: 'auto', opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={{
+                height: ARTIST_EXPAND_TRANSITION,
+                opacity: { duration: 0.2, ease: 'easeOut' },
+              }}
+            >
+              <div className={styles.artistGrid}>
+                {hiddenArtists.map((artist) => (
+                  <figure
+                    key={artist.artistId}
+                    className={styles.festivalArtistContainer}
+                  >
+                    <Avatar
+                      size="lg"
+                      src={artist.profileUrl}
+                      isHandleClick={false}
+                    />
+                    <p className={styles.festivalArtistName}>{artist.name}</p>
+                  </figure>
+                ))}
               </div>
-            )}
-          </div>
-        ))}
-      </section>
-    </>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+      {!isEmpty(hiddenArtists) && (
+        <div className={styles.festivalMorebutton}>
+          <MoreButton
+            showExpanded={showExpandedArtists}
+            onToggle={handleToggleExpandedArtists}
+          />
+        </div>
+      )}
+    </div>
   );
 };
+
+interface FestivalArtistSectionProps {
+  artists: FestivalDate[];
+}
+
+const FestivalArtistSection = ({ artists }: FestivalArtistSectionProps) => (
+  <>
+    <div className={styles.festivalArtistTitle}>
+      <ArtistSectionTitle />
+    </div>
+    <section className={styles.festivalContentContainer}>
+      {artists.map((festivalDate) => (
+        <FestivalArtistDateSection
+          key={festivalDate.festivalDateId}
+          festivalDate={festivalDate}
+        />
+      ))}
+    </section>
+  </>
+);
 
 export default FestivalArtistSection;

--- a/apps/client/src/pages/performance/components/artist/festival-artist-section.tsx
+++ b/apps/client/src/pages/performance/components/artist/festival-artist-section.tsx
@@ -1,9 +1,9 @@
-import { useState } from 'react';
-import { AnimatePresence, motion } from 'motion/react';
+import { useId, useState } from 'react';
 
 import { Avatar } from '@confeti/design-system';
 
 import { logClickEvent } from '@shared/analytics/logging';
+import Collapse from '@shared/components/collapse/collapse';
 import { drop, isEmpty, take } from '@shared/lib/es-toolkit/es';
 import { FestivalDate } from '@shared/types/festival-response';
 
@@ -13,10 +13,6 @@ import ArtistSectionTitle from './artist-section-title';
 import * as styles from './festival-artist-section.css';
 
 const MAX_ARTIST_LENGTH = 4;
-const ARTIST_EXPAND_TRANSITION = {
-  duration: 0.35,
-  ease: 'easeOut',
-} as const;
 
 const FestivalArtistDateSection = ({
   festivalDate,
@@ -24,7 +20,9 @@ const FestivalArtistDateSection = ({
   festivalDate: FestivalDate;
 }) => {
   const [showExpandedArtists, setShowExpandedArtists] = useState(false);
+  const artistRegionId = useId();
   const hiddenArtists = drop(festivalDate.artists, MAX_ARTIST_LENGTH);
+  const showMoreButton = !isEmpty(hiddenArtists);
 
   const handleToggleExpandedArtists = () => {
     logClickEvent({
@@ -37,7 +35,7 @@ const FestivalArtistDateSection = ({
   };
 
   return (
-    <div className={styles.festivalContentItems}>
+    <section className={styles.festivalContentItems}>
       <p className={styles.festivalDayBadge}>{festivalDate.festivalAt}</p>
       <div className={styles.artistList}>
         <div className={styles.artistGrid}>
@@ -51,18 +49,15 @@ const FestivalArtistDateSection = ({
             </figure>
           ))}
         </div>
-        <AnimatePresence initial={false}>
-          {showExpandedArtists && (
-            <motion.div
-              className={styles.expandedArtistGrid}
-              initial={{ height: 0, opacity: 0 }}
-              animate={{ height: 'auto', opacity: 1 }}
-              exit={{ height: 0, opacity: 0 }}
-              transition={{
-                height: ARTIST_EXPAND_TRANSITION,
-                opacity: { duration: 0.2, ease: 'easeOut' },
-              }}
-            >
+        {showMoreButton && (
+          <Collapse
+            id={artistRegionId}
+            className={styles.artistCollapseRegion}
+            role="region"
+            aria-hidden={!showExpandedArtists}
+            isExpanded={showExpandedArtists}
+          >
+            <div className={styles.artistCollapseRegionInner}>
               <div className={styles.artistGrid}>
                 {hiddenArtists.map((artist) => (
                   <figure
@@ -78,19 +73,20 @@ const FestivalArtistDateSection = ({
                   </figure>
                 ))}
               </div>
-            </motion.div>
-          )}
-        </AnimatePresence>
+            </div>
+          </Collapse>
+        )}
       </div>
-      {!isEmpty(hiddenArtists) && (
+      {showMoreButton && (
         <div className={styles.festivalMorebutton}>
           <MoreButton
-            showExpanded={showExpandedArtists}
+            controlsId={artistRegionId}
+            isExpanded={showExpandedArtists}
             onToggle={handleToggleExpandedArtists}
           />
         </div>
       )}
-    </div>
+    </section>
   );
 };
 

--- a/apps/client/src/pages/performance/components/button/more-button.tsx
+++ b/apps/client/src/pages/performance/components/button/more-button.tsx
@@ -14,20 +14,22 @@ const MORE_BUTTON = {
 } as const;
 
 interface MoreButtonProps {
+  controlsId?: string;
   hasShadow?: boolean;
-  showExpanded: boolean;
+  isExpanded: boolean;
   onToggle: () => void;
 }
 
 const MoreButton = ({
+  controlsId,
   hasShadow = false,
-  showExpanded,
+  isExpanded,
   onToggle,
 }: MoreButtonProps) => {
-  const buttonText = showExpanded
+  const buttonText = isExpanded
     ? MORE_BUTTON.EXPANDED.TEXT
     : MORE_BUTTON.COLLAPSED.TEXT;
-  const ariaLabel = showExpanded
+  const ariaLabel = isExpanded
     ? MORE_BUTTON.EXPANDED.ARIA_LABEL
     : MORE_BUTTON.COLLAPSED.ARIA_LABEL;
 
@@ -35,10 +37,12 @@ const MoreButton = ({
     <button
       className={styles.button({ hasShadow })}
       onClick={onToggle}
+      aria-controls={controlsId}
+      aria-expanded={isExpanded}
       aria-label={ariaLabel}
     >
       <span className={styles.text}>{buttonText}</span>
-      {showExpanded ? (
+      {isExpanded ? (
         <Icon name="arrow-vertical" size="1.6rem" />
       ) : (
         <Icon name="arrow-vertical" size="1.6rem" rotate={180} />

--- a/apps/client/src/pages/performance/components/button/more-button.tsx
+++ b/apps/client/src/pages/performance/components/button/more-button.tsx
@@ -15,19 +15,19 @@ const MORE_BUTTON = {
 
 interface MoreButtonProps {
   hasShadow?: boolean;
-  isExpanded: boolean;
+  showExpanded: boolean;
   onToggle: () => void;
 }
 
 const MoreButton = ({
   hasShadow = false,
-  isExpanded,
+  showExpanded,
   onToggle,
 }: MoreButtonProps) => {
-  const buttonText = isExpanded
+  const buttonText = showExpanded
     ? MORE_BUTTON.EXPANDED.TEXT
     : MORE_BUTTON.COLLAPSED.TEXT;
-  const ariaLabel = isExpanded
+  const ariaLabel = showExpanded
     ? MORE_BUTTON.EXPANDED.ARIA_LABEL
     : MORE_BUTTON.COLLAPSED.ARIA_LABEL;
 
@@ -38,7 +38,7 @@ const MoreButton = ({
       aria-label={ariaLabel}
     >
       <span className={styles.text}>{buttonText}</span>
-      {isExpanded ? (
+      {showExpanded ? (
         <Icon name="arrow-vertical" size="1.6rem" />
       ) : (
         <Icon name="arrow-vertical" size="1.6rem" rotate={180} />

--- a/apps/client/src/shared/components/collapse/collapse.css.ts
+++ b/apps/client/src/shared/components/collapse/collapse.css.ts
@@ -1,0 +1,39 @@
+import { recipe } from '@vanilla-extract/recipes';
+
+export const root = recipe({
+  base: {
+    width: '100%',
+    display: 'grid',
+    gridTemplateRows: '0fr',
+    transition: 'grid-template-rows 280ms ease',
+  },
+  variants: {
+    isExpanded: {
+      true: {
+        gridTemplateRows: '1fr',
+      },
+      false: {
+        gridTemplateRows: '0fr',
+      },
+    },
+  },
+});
+
+export const content = recipe({
+  base: {
+    minHeight: 0,
+    overflow: 'hidden',
+    opacity: 0,
+    transition: 'opacity 180ms ease',
+  },
+  variants: {
+    isExpanded: {
+      true: {
+        opacity: 1,
+      },
+      false: {
+        opacity: 0,
+      },
+    },
+  },
+});

--- a/apps/client/src/shared/components/collapse/collapse.tsx
+++ b/apps/client/src/shared/components/collapse/collapse.tsx
@@ -1,0 +1,26 @@
+import { type ComponentPropsWithoutRef, type ReactNode } from 'react';
+
+import { cn } from '@confeti/utils';
+
+import * as styles from './collapse.css';
+
+interface CollapseProps
+  extends Omit<ComponentPropsWithoutRef<'div'>, 'children'> {
+  children: ReactNode;
+  isExpanded: boolean;
+}
+
+const Collapse = ({
+  children,
+  className,
+  isExpanded,
+  ...props
+}: CollapseProps) => {
+  return (
+    <div className={cn(styles.root({ isExpanded }), className)} {...props}>
+      <div className={styles.content({ isExpanded })}>{children}</div>
+    </div>
+  );
+};
+
+export default Collapse;

--- a/apps/client/src/shared/components/index.ts
+++ b/apps/client/src/shared/components/index.ts
@@ -1,3 +1,4 @@
+export { default as Collapse } from './collapse/collapse';
 export { default as FloatingButtonContainer } from './containers/floating-button-container';
 export { FestivalList } from './festival-list/festival-list';
 export { default as Hero } from './hero/hero';

--- a/apps/client/src/shared/lib/es-toolkit/es.ts
+++ b/apps/client/src/shared/lib/es-toolkit/es.ts
@@ -1,5 +1,14 @@
 // Array
-export { chunk, compact, groupBy, sortBy, uniq, uniqBy } from 'es-toolkit';
+export {
+  chunk,
+  compact,
+  drop,
+  groupBy,
+  sortBy,
+  take,
+  uniq,
+  uniqBy,
+} from 'es-toolkit';
 
 // Object
 export { cloneDeep, merge, omit, pick } from 'es-toolkit';

--- a/packages/analytics-catalog/src/generated/analytics-catalog.ts
+++ b/packages/analytics-catalog/src/generated/analytics-catalog.ts
@@ -1,7 +1,7 @@
 import type { AnalyticsCatalogData } from '../types';
 
 export const analyticsCatalog = {
-  generatedAt: '2026-04-01T15:41:55.967Z',
+  generatedAt: '2026-04-12T17:58:24.588Z',
   rows: [
     {
       page: '*',
@@ -348,7 +348,7 @@ export const analyticsCatalog = {
       state: 'show_festival_detail',
       attribute: '',
       commonComponent: '',
-      element: 'handler:toggleExpanded',
+      element: 'handler:handleToggleExpandedArtists',
       eventType: 'click',
       eventName: 'click_box_show_more',
       showType: '',
@@ -361,8 +361,8 @@ export const analyticsCatalog = {
       ],
       sourceFile:
         'pages/performance/components/artist/festival-artist-section.tsx',
-      sourceComponent: 'toggleExpanded',
-      sourceLine: 26,
+      sourceComponent: 'handleToggleExpandedArtists',
+      sourceLine: 28,
     },
     {
       page: '/festival-detail/:festivalId',


### PR DESCRIPTION
## 📌 Summary

> 관련 있는 Issue를 태그해주세요. (e.g. > - #100)

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

## 📚 Tasks

- 공연 상세 아티스트 더보기의 기존 `max-height` 기반 구현을 제거했어요.
- motion.dev 아티클에서 설명한 것처럼, 레이아웃을 크게 흔드는 통짜 애니메이션보다 변화 범위를 전용 영역으로 좁히는 방향으로 구조를 다시 잡았어요.
- 페이지 컴포넌트 안에 애니메이션 세부 구현이 새지 않도록, 재사용 가능한 `Collapse` 컴포넌트를 새로 추가했어요.
- `FestivalArtistSection`은 기존 UI를 유지한 채 `DAY 배지 -> 기본 아티스트 그리드 -> 더보기 버튼 -> 추가 아티스트 영역` 구조로 정리하고, `MoreButton + Collapse` 조합만 사용하도록 단순화했어요.
- 기본 4명과 추가 노출 아티스트 영역을 분리해서, 더보기/접기 시 추가 아티스트 영역만 접고 펼치도록 변경했어요.
- 아티스트 노출 로직은 `take`, `drop`, `isEmpty`를 사용해 선언적으로 정리했어요.
- `MoreButton`에 `aria-controls`, `aria-expanded`를 추가해서 접힘 영역과의 접근성을 보완했어요.
- 변경 범위는 `eslint`와 `tsc --noEmit`로 검증했어요.

## 👀 To Reviewer

초기 구현은 전체 아티스트 그리드에 `max-height`를 걸어서 더보기와 접기를 처리하고 있었어요. motion.dev 아티클의 렌더 파이프라인 관점에서 보면 이런 방식은 레이아웃 비용이 큰 편이라, 콘텐츠 양이 많아질수록 체감이 어색해질 수 있었어요. 이번에는 UI는 그대로 유지하면서, MUI의 `Accordion/Collapse`처럼 페이지 컴포넌트에는 상태와 마크업만 남기고 접힘 동작은 별도 `Collapse`로 분리했어요. 더보기 버튼 아래의 추가 아티스트 영역만 자연스럽게 열리고 닫히는지, 그리고 `Collapse` 추상화 수준이 과하지 않은지 중심으로 봐주시면 좋겠어요.




## 📸 Screenshot


### 이전
https://github.com/user-attachments/assets/2fd8a7dc-fa89-413c-9672-138b64c03d14

## 이후
https://github.com/user-attachments/assets/d7984636-0ebe-43a1-8caf-313de529532a

