### PR TITLE
Fix(Admin): 페스티벌 타임테이블 시간 포맷 수정

### DIFF
--- a/apps/admin/src/pages/performance-editor/performance-editor-helpers.ts
+++ b/apps/admin/src/pages/performance-editor/performance-editor-helpers.ts
@@ -52,9 +52,6 @@ const withSeconds = (value: string) => {
   return value;
 };
 
-const formatDateTime = (date: string, time: string) =>
-  withSeconds(`${date}T${time}`);
-
 const extractDate = (value: string) => value.split('T')[0] ?? value;
 
 const extractTime = (value: string) =>

--- a/apps/admin/src/pages/performance-editor/performance-editor-helpers.ts
+++ b/apps/admin/src/pages/performance-editor/performance-editor-helpers.ts
@@ -60,12 +60,12 @@ const extractDate = (value: string) => value.split('T')[0] ?? value;
 const extractTime = (value: string) =>
   value.split('T')[1]?.slice(0, 5) ?? value;
 
-const getFestivalOpenAt = (date: string, slots: TimetableSlot[]) => {
+const getFestivalOpenAt = (slots: TimetableSlot[]) => {
   const earliestSlot = [...slots].sort((left, right) =>
     left.startTime.localeCompare(right.startTime),
   )[0];
 
-  return formatDateTime(date, earliestSlot?.startTime ?? '00:00');
+  return withSeconds(earliestSlot?.startTime ?? '00:00');
 };
 
 const getFestivalDates = (
@@ -93,8 +93,8 @@ const getFestivalDates = (
           .filter((slot) => slot.stageIndex === stageIndex)
           .map((slot) => ({
             festivalTimeId: slot.festivalTimeId,
-            startAt: formatDateTime(date, slot.startTime),
-            endAt: formatDateTime(date, slot.endTime),
+            startAt: withSeconds(slot.startTime),
+            endAt: withSeconds(slot.endTime),
             artistIds: [String(slot.artistId)],
           })),
       }))
@@ -104,8 +104,8 @@ const getFestivalDates = (
       festivalDateId: festivalDateMeta?.festivalDateId,
       festivalAt: date,
       openAt: festivalDateMeta?.openAt
-        ? formatDateTime(date, festivalDateMeta.openAt)
-        : getFestivalOpenAt(date, slotsForDate),
+        ? withSeconds(festivalDateMeta.openAt)
+        : getFestivalOpenAt(slotsForDate),
       artistIds: formData.artists
         .filter((artist) => artist.festivalDates?.includes(date) ?? false)
         .map((artist) => String(artist.id)),


### PR DESCRIPTION
## 원인

서버 `PutAdminFestivalRequest`의 `DateRequest.openAt`, `TimeRequest.startAt/endAt` 필드가 `LocalTime` 타입(`HH:mm:ss`)인데, 프론트에서 `formatDateTime(date, time)` 함수로 `LocalDateTime` 형식(`YYYY-MM-DDTHH:mm:ss`)을 전송해 Jackson 역직렬화 실패 → **400 Bad Request** 발생.

서버는 최초 구현(CSERVER-12)부터 `LocalTime`을 사용해왔으며 변경된 적 없음. 프론트 타입이 `string`으로 정의되어 TS 컴파일 단계에서는 잡히지 않았음.

## 변경 내용

`performance-editor-helpers.ts`의 `getFestivalDates` / `getFestivalOpenAt` 함수에서 시간 필드를 시간만 전송하도록 수정, 이후 미사용 `formatDateTime` 함수 제거

| 필드 | 기존 | 수정 |
|---|---|---|
| `DateRequest.openAt` | `"2026-05-23T12:00:00"` | `"12:00:00"` |
| `TimeRequest.startAt` | `"2026-05-23T18:00:00"` | `"18:00:00"` |
| `TimeRequest.endAt` | `"2026-05-23T19:00:00"` | `"19:00:00"` |