### PR TITLE
Fix(Admin): 타임테이블 Zod 스키마 시간 형식 수정 및 SSOT 적용

### DIFF
--- a/apps/admin/src/pages/performance-editor/performance-editor-helpers.ts
+++ b/apps/admin/src/pages/performance-editor/performance-editor-helpers.ts
@@ -36,21 +36,13 @@ const formatPrice = (price: string) => {
   return `${Number(numericPrice).toLocaleString('ko-KR')}원`;
 };
 
-const withSeconds = (value: string) => {
-  if (!value) {
-    return value;
-  }
+const TIME_FORMAT_REGEX = /^\d{2}:\d{2}(:\d{2})?$/;
 
-  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/.test(value)) {
-    return value;
-  }
+const toTimeString = (value: string): string =>
+  /^\d{2}:\d{2}$/.test(value) ? `${value}:00` : value;
 
-  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(value)) {
-    return `${value}:00`;
-  }
-
-  return value;
-};
+const toDateTimeString = (value: string): string =>
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(value) ? `${value}:00` : value;
 
 const extractDate = (value: string) => value.split('T')[0] ?? value;
 
@@ -62,7 +54,7 @@ const getFestivalOpenAt = (slots: TimetableSlot[]) => {
     left.startTime.localeCompare(right.startTime),
   )[0];
 
-  return withSeconds(earliestSlot?.startTime ?? '00:00');
+  return toTimeString(earliestSlot?.startTime ?? '00:00');
 };
 
 const getFestivalDates = (
@@ -90,8 +82,8 @@ const getFestivalDates = (
           .filter((slot) => slot.stageIndex === stageIndex)
           .map((slot) => ({
             festivalTimeId: slot.festivalTimeId,
-            startAt: withSeconds(slot.startTime),
-            endAt: withSeconds(slot.endTime),
+            startAt: toTimeString(slot.startTime),
+            endAt: toTimeString(slot.endTime),
             artistIds: [String(slot.artistId)],
           })),
       }))
@@ -101,7 +93,7 @@ const getFestivalDates = (
       festivalDateId: festivalDateMeta?.festivalDateId,
       festivalAt: date,
       openAt: festivalDateMeta?.openAt
-        ? withSeconds(festivalDateMeta.openAt)
+        ? toTimeString(festivalDateMeta.openAt)
         : getFestivalOpenAt(slotsForDate),
       artistIds: formData.artists
         .filter((artist) => artist.festivalDates?.includes(date) ?? false)
@@ -130,7 +122,7 @@ const festivalOpenAtSchema = z
   .string()
   .trim()
   .min(1, '티켓 오픈 시간을 입력해주세요.')
-  .regex(/^\d{2}:\d{2}(:\d{2})?$/, '티켓 오픈 시간 형식이 올바르지 않아요.');
+  .regex(TIME_FORMAT_REGEX, '티켓 오픈 시간 형식이 올바르지 않아요.');
 
 const reservationScheduleSchema = z.object({
   roundName: z.string().trim().max(30, '예매 차수는 30자 이하여야 해요.'),
@@ -165,7 +157,7 @@ const timetableTimeSchema = z
   .string()
   .trim()
   .min(1, '타임테이블 시간을 입력해주세요.')
-  .regex(/^\d{2}:\d{2}(:\d{2})?$/, '타임테이블 시간 형식이 올바르지 않아요.');
+  .regex(TIME_FORMAT_REGEX, '타임테이블 시간 형식이 올바르지 않아요.');
 
 const festivalTimeSchema = z.object({
   festivalTimeId: z.number().optional(),
@@ -334,7 +326,7 @@ const getReservationSchedules = (
     .filter((schedule) => schedule.startDate.trim().length > 0)
     .map((schedule) => ({
       roundName: schedule.round.trim(),
-      reserveAt: withSeconds(schedule.startDate),
+      reserveAt: toDateTimeString(schedule.startDate),
     }));
 
 export const buildConcertRequest = (

--- a/apps/admin/src/pages/performance-editor/performance-editor-helpers.ts
+++ b/apps/admin/src/pages/performance-editor/performance-editor-helpers.ts
@@ -130,10 +130,7 @@ const festivalOpenAtSchema = z
   .string()
   .trim()
   .min(1, '티켓 오픈 시간을 입력해주세요.')
-  .regex(
-    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?$/,
-    '티켓 오픈 시간 형식이 올바르지 않아요.',
-  );
+  .regex(/^\d{2}:\d{2}(:\d{2})?$/, '티켓 오픈 시간 형식이 올바르지 않아요.');
 
 const reservationScheduleSchema = z.object({
   roundName: z.string().trim().max(30, '예매 차수는 30자 이하여야 해요.'),
@@ -164,10 +161,16 @@ const concertRequestSchema = z.object({
   ),
 });
 
+const timetableTimeSchema = z
+  .string()
+  .trim()
+  .min(1, '타임테이블 시간을 입력해주세요.')
+  .regex(/^\d{2}:\d{2}(:\d{2})?$/, '타임테이블 시간 형식이 올바르지 않아요.');
+
 const festivalTimeSchema = z.object({
   festivalTimeId: z.number().optional(),
-  startAt: reservationDateTimeSchema,
-  endAt: reservationDateTimeSchema,
+  startAt: timetableTimeSchema,
+  endAt: timetableTimeSchema,
   artistIds: z
     .array(z.string().trim().min(1))
     .min(1, '타임테이블에 아티스트를 추가해주세요.'),


### PR DESCRIPTION
## 원인

이전 PR(#853)에서 타임테이블 시간 필드를 `LocalDateTime` → `LocalTime` 형식으로 수정했으나, 프론트 Zod 스키마의 정규식이 여전히 `LocalDateTime` 형식을 기대하고 있어 저장 버튼 클릭 시 서버 호출 전에 유효성 검사 실패 → 토스트 에러 발생.

또한 시간 포맷이 `withSeconds` 함수, Zod 스키마 정규식에 각각 중복 정의되어 있어 SSOT를 위반하고 있었음.

## 변경 내용

### 포맷 정의 단일화
- `TIME_FORMAT_REGEX` 상수로 `LocalTime` 포맷(`HH:mm(:ss)?`)을 한 곳에서 정의
- `festivalOpenAtSchema`, `timetableTimeSchema` 모두 해당 상수 공유

### 함수 분리
| 기존 | 변경 | 용도 |
|---|---|---|
| `withSeconds` | `toTimeString` | `LocalTime` (`HH:mm` → `HH:mm:ss`) |
| `withSeconds` | `toDateTimeString` | `LocalDateTime` (`YYYY-MM-DDTHH:mm` → `YYYY-MM-DDTHH:mm:ss`) |

### 스키마 수정
- `festivalOpenAtSchema`: `YYYY-MM-DDTHH:mm` → `HH:mm(:ss)?`
- `timetableTimeSchema` (신규): `reservationDateTimeSchema`에서 분리