### PR TITLE
Refactor(Client): 콘서트/페스티벌 예매처 응답 ticketVendor 중첩 스키마 적응

### DIFF
--- a/apps/client/src/pages/performance/components/reservation/reservation.tsx
+++ b/apps/client/src/pages/performance/components/reservation/reservation.tsx
@@ -4,8 +4,10 @@ import * as styles from './reservation.css';
 
 interface ReservationItem {
   url: string;
-  name: string;
-  logoUrl: string;
+  ticketVendor: {
+    name: string;
+    logoUrl: string;
+  };
 }
 
 interface Props {
@@ -29,21 +31,21 @@ const Reservation = ({ reservations }: Props) => {
     <section className={styles.container}>
       <h2 className={styles.title}>예매처 바로가기</h2>
       <ul className={styles.list}>
-        {reservationItems.map(({ key, name, logoUrl, handleClick }) => (
+        {reservationItems.map(({ key, ticketVendor, handleClick }) => (
           <li key={key} className={styles.item}>
             <LogClickEvent
               name="click_reservation_link"
-              params={{ vendor: name }}
+              params={{ vendor: ticketVendor.name }}
             >
               <button className={styles.logoButton} onClick={handleClick}>
                 <img
-                  src={logoUrl}
-                  alt={`${name} 로고`}
+                  src={ticketVendor.logoUrl}
+                  alt={`${ticketVendor.name} 로고`}
                   className={styles.logo}
                 />
               </button>
             </LogClickEvent>
-            <span className={styles.name}>{name}</span>
+            <span className={styles.name}>{ticketVendor.name}</span>
           </li>
         ))}
       </ul>

--- a/apps/client/src/shared/types/concert-response.ts
+++ b/apps/client/src/shared/types/concert-response.ts
@@ -4,9 +4,13 @@ export interface Concert extends PerformanceBase {
   concertId: number;
   address: string;
   reservations: {
+    reservationId: number;
     url: string;
-    name: string;
-    logoUrl: string;
+    ticketVendor: {
+      ticketVendorId: number;
+      name: string;
+      logoUrl: string;
+    };
   }[];
 }
 

--- a/apps/client/src/shared/types/festival-response.ts
+++ b/apps/client/src/shared/types/festival-response.ts
@@ -4,9 +4,13 @@ export interface Festival extends PerformanceBase {
   festivalId: number;
   address: string;
   reservations: {
+    reservationId: number;
     url: string;
-    name: string;
-    logoUrl: string;
+    ticketVendor: {
+      ticketVendorId: number;
+      name: string;
+      logoUrl: string;
+    };
   }[];
 }
 


### PR DESCRIPTION
## 요약

서버 변경(`CSERVER-54` #635, `CSERVER-57` #638)으로 Concert/Festival reservation 응답이 평탄 형태에서 `ticketVendor` 중첩 구조로 변경되었습니다. 이에 맞춰 클라이언트 타입 정의와 `Reservation` 컴포넌트를 정정합니다.

## 변경 사항

- `concert-response.ts`: `Concert.reservations` 자식 타입 평탄 → `ticketVendor` 중첩 + `reservationId`/`ticketVendorId` 필드 추가
- `festival-response.ts`: `Festival.reservations` 자식 타입 동일 정정
- `reservation.tsx`: `ReservationItem` 인터페이스 + 컴포넌트 본문의 `name`/`logoUrl` 평탄 분해를 `ticketVendor.name`/`ticketVendor.logoUrl` 중첩 접근으로 변경

## 응답 스키마 변경 (서버 PR 참조)

```
// Before
{ reservationId, url, name, logoUrl }                              (Concert, 서버 PR 이전)
{ url, name, logoUrl }                                              (Festival, CSERVER-49 이전)

// After
{ reservationId, url, ticketVendor: { ticketVendorId, name, logoUrl } }
```

- Concert: 서버 PR #635 (`CSERVER-54`)에서 변경
- Festival: 서버 PR #638 (`CSERVER-57`)에서 통일 (`ticketVendorResponse` → `ticketVendor`)

## 영향

- Concert 상세 페이지, Festival 상세 페이지 예매처 섹션
- 분석 이벤트 `params.vendor` 값은 동일하게 vendor name 문자열 — 페이로드 변경 없음

## 검증

- ✅ `pnpm --filter @confeti/client run build` BUILD SUCCESSFUL (`tsc -b` 통과)
- ✅ husky + lint-staged (ESLint + Prettier) 통과
- 로컬 시각 확인 권장: 콘서트/페스티벌 상세에서 예매처 로고/이름 정상 표시

## 배포

서버 시리즈(CSERVER-47~57)가 다음 운영 release(`main` 머지) 사이클에 함께 가므로, 본 PR도 동일 사이클에 머지되어야 합니다.