### PR TITLE
Fix(Admin): 예매처 응답 필드명 logoPath → logoUrl 정정

### DIFF
--- a/apps/admin/src/pages/performance-editor/components/basic-info-tab.tsx
+++ b/apps/admin/src/pages/performance-editor/components/basic-info-tab.tsx
@@ -248,7 +248,7 @@ export const BasicInfoTab = ({
               }
             >
               <img
-                src={platform.logoPath}
+                src={platform.logoUrl}
                 alt={platform.name}
                 className={styles.ticketingPlatformIcon}
               />
@@ -261,7 +261,7 @@ export const BasicInfoTab = ({
           <div key={platform.id} className={styles.ticketingPlatformCard}>
             <div className={styles.ticketingPlatformCardHeader}>
               <img
-                src={ticketVendors.find((v) => v.id === platform.id)?.logoPath}
+                src={ticketVendors.find((v) => v.id === platform.id)?.logoUrl}
                 alt={platform.name}
                 className={styles.ticketingPlatformLogo}
               />

--- a/apps/admin/src/pages/ticketing-platform/ticketing-platform-page.tsx
+++ b/apps/admin/src/pages/ticketing-platform/ticketing-platform-page.tsx
@@ -50,7 +50,7 @@ const TicketingPlatformPage = () => {
     setFormMode('edit');
     setEditingTicketingPlatform(ticketVendor);
     setTicketingPlatformName(ticketVendor.name);
-    setLogoPreview(ticketVendor.logoPath || null);
+    setLogoPreview(ticketVendor.logoUrl || null);
     setLogoFile(null);
   };
 
@@ -248,9 +248,9 @@ const TicketingPlatformPage = () => {
               className={styles.card}
             >
               <div className={styles.cardLogo}>
-                {ticketVendor.logoPath ? (
+                {ticketVendor.logoUrl ? (
                   <img
-                    src={ticketVendor.logoPath}
+                    src={ticketVendor.logoUrl}
                     alt={ticketVendor.name}
                     className={styles.cardLogoImage}
                   />

--- a/apps/admin/src/shared/types/api.ts
+++ b/apps/admin/src/shared/types/api.ts
@@ -297,7 +297,7 @@ export type UpdateDraftRequest = {
 export type TicketVendorResponse = {
   id: number;
   name: string;
-  logoPath: string;
+  logoUrl: string;
 };
 
 export type TicketVendorListResponse = {


### PR DESCRIPTION
## 요약

어드민 페이지에서 예매처 로고 이미지가 표시되지 않는 버그 수정. 서버 응답은 `logoUrl`로 내려주는데 admin 타입과 사용처가 `logoPath`로 접근하고 있어 `undefined`로 평가되어 `<img src={undefined}>`로 렌더링됨 → src 속성 누락 → 빈 이미지.

## 원인

서버 응답 형식:
```json
{
  "ticketVendors": [
    { "id": 1, "name": "멜론티켓", "logoUrl": "https://files.confeti.asia/ticket-vendor/logo/..." }
  ]
}
```

그러나 admin 타입 정의가 `logoPath`로 잘못되어 있었음:
```ts
export type TicketVendorResponse = {
  id: number;
  name: string;
  logoPath: string;  // ❌ 서버는 logoUrl을 보냄
};
```

## 변경 사항 (6곳)

| 파일 | 변경 |
|----|----|
| `apps/admin/src/shared/types/api.ts` | `TicketVendorResponse.logoPath` → `logoUrl` |
| `apps/admin/src/pages/performance-editor/components/basic-info-tab.tsx` | 예매처 선택 pill `<img src>` + 선택된 카드 로고 `<img src>` |
| `apps/admin/src/pages/ticketing-platform/ticketing-platform-page.tsx` | 카드 로고 표시 조건/`<img src>` + 편집 폼 미리보기 |

## 영향

- 어드민의 공연 편집 페이지: 예매처 선택 pill의 로고 이미지 정상 표시
- 어드민의 예매처 관리 페이지: 카드 로고 + 편집 폼 미리보기 정상 표시

## 검증

- ✅ `pnpm --filter @confeti/admin run build` 성공 (`tsc -b` 통과)
- ✅ husky + lint-staged (ESLint + Prettier) 통과
- ✅ admin 영역 `logoPath` 잔재 grep 0건 (`logoPreview` / `logoImage` 등 다른 컨텍스트 제외)

## 관련

서버 응답 키는 `logoUrl`로 유지된 상태이며 본 PR은 클라이언트 측 mismatch만 정정. 별도 서버 변경 불필요.