### PR TITLE
Chore(Client): 분석 카탈로그 재생성

### DIFF
--- a/packages/analytics-catalog/src/generated/analytics-catalog.ts
+++ b/packages/analytics-catalog/src/generated/analytics-catalog.ts
@@ -1,7 +1,7 @@
 import type { AnalyticsCatalogData } from '../types';
 
 export const analyticsCatalog = {
-  generatedAt: '2026-04-13T08:02:02.157Z',
+  generatedAt: '2026-06-01T13:56:26.024Z',
   rows: [
     {
       page: '*',
@@ -633,20 +633,6 @@ export const analyticsCatalog = {
       params: [],
       sourceFile: 'pages/my/components/artist/no-artist-section.tsx',
       sourceComponent: 'NoArtistSection',
-    },
-    {
-      page: '/my',
-      path: '/my',
-      state: 'show_my_profile',
-      attribute: '',
-      commonComponent: '',
-      element: 'button',
-      eventType: 'click',
-      eventName: 'click_my_profile_setting',
-      showType: '',
-      params: [],
-      sourceFile: 'pages/my/page/profile/my-profile.tsx',
-      sourceComponent: 'MyProfile',
     },
     {
       page: '/my/artist',
@@ -2321,26 +2307,6 @@ export const analyticsCatalog = {
       sourceFile:
         'pages/setlist/components/add-setlist/setlist-performance.tsx',
       sourceComponent: 'handleFestivalSelect',
-    },
-    {
-      page: '/setlist/maintenance',
-      path: '/setlist/maintenance',
-      state: '',
-      attribute: '공통',
-      commonComponent: 'NavigationTabs',
-      element: 'Navigation.Item',
-      eventType: 'click',
-      eventName: 'click_navigation_tab',
-      showType: '',
-      params: [
-        {
-          name: 'tab',
-          type: 'enum: home, timetable, setlist',
-          required: true,
-        },
-      ],
-      sourceFile: 'shared/components/navigation-tabs.tsx',
-      sourceComponent: 'NavigationTabs',
     },
     {
       page: '/setlist/maintenance',


### PR DESCRIPTION
## 📌 Summary

릴리즈 PR(#867)의 `analytics:check`가 깨지던 걸 해결합니다. 코드에서 분석 카탈로그를 재생성해 stale drift를 해소합니다. (build/test/coverage는 실제 실패가 아니라 matrix fail-fast로 취소된 것)

## 📚 Tasks

- `pnpm analytics:generate` 결과 반영 (`analytics-catalog.ts`)
- 바텀탭/헤더로 옮겨간 네비 이벤트(`click_navigation_tab`, `click_my_profile_setting`)의 stale 엔트리 제거
  - 두 이벤트는 런타임에선 정상 발화하지만, 글로벌 레이아웃 레벨 컴포넌트라 카탈로그 정적 스캐너의 라우트 귀속 대상이 아니에요(기존 `click_navigation_logo`도 동일하게 미수집).

## 👀 To Reviewer

코드 변경 없이 생성물(catalog)만 갱신된 PR이에요.
