### PR TITLE
Fix(Client): 바텀탭 도입 후속 레이아웃 보정 (홈 캐러셀 간격, 셋리스트 maintenance)

### DIFF
--- a/apps/client/src/pages/home/components/performance-carousel-section.css.ts
+++ b/apps/client/src/pages/home/components/performance-carousel-section.css.ts
@@ -5,12 +5,12 @@ import { themeVars } from '@confeti/design-system/styles';
 export const sectionContainer = style({
   position: 'relative',
   width: '100%',
-  height: '56.4rem',
+  height: '52rem',
   overflow: 'hidden',
   marginTop: 0,
   selectors: {
     '.cap-native &': {
-      height: 'calc(56.4rem + var(--safe-area-top))',
+      height: 'calc(52rem + var(--safe-area-top))',
     },
   },
 });

--- a/apps/client/src/pages/home/components/performance-carousel/components/performance-carousel.css.ts
+++ b/apps/client/src/pages/home/components/performance-carousel/components/performance-carousel.css.ts
@@ -6,10 +6,10 @@ export const root = style({
   overflow: 'visible',
   userSelect: 'none',
   touchAction: 'none',
-  marginTop: '8rem',
+  marginTop: '3.6rem',
   selectors: {
     '.cap-native &': {
-      marginTop: 'calc(8rem + var(--safe-area-top))',
+      marginTop: 'calc(3.6rem + var(--safe-area-top))',
     },
   },
 });

--- a/apps/client/src/pages/setlist/page/maintenance/maintenance-page.tsx
+++ b/apps/client/src/pages/setlist/page/maintenance/maintenance-page.tsx
@@ -12,7 +12,8 @@ const MaintenancePage = () => {
       <LogShowEvent name="show_setlist_maintenance" />
       <AppSafeArea
         flexible
-        subtract={LAYOUT_HEIGHT.GLOBAL_HEADER}
+        insets="top"
+        subtract={`calc(${LAYOUT_HEIGHT.GLOBAL_HEADER} + ${LAYOUT_HEIGHT.BOTTOM_NAVIGATION})`}
         className={styles.container}
       >
         <img

--- a/apps/client/src/shared/components/layout/bottom-navigation-bar.css.ts
+++ b/apps/client/src/shared/components/layout/bottom-navigation-bar.css.ts
@@ -2,8 +2,7 @@ import { style } from '@vanilla-extract/css';
 
 import { themeVars } from '@confeti/design-system/styles';
 
-// fixed 탭바 높이(Figma 78px = 버튼 5.8rem + paddingBottom). spacer로 콘텐츠 가림 방지.
-const BAR_HEIGHT = 'calc(5.8rem + max(2rem, env(safe-area-inset-bottom)))';
+import { LAYOUT_HEIGHT } from '@shared/constants/layout';
 
 export const fixedWrapper = style({
   position: 'fixed',
@@ -18,6 +17,6 @@ export const fixedWrapper = style({
 
 export const spacer = style({
   width: '100%',
-  height: BAR_HEIGHT,
+  height: LAYOUT_HEIGHT.BOTTOM_NAVIGATION,
   flexShrink: 0,
 });

--- a/apps/client/src/shared/constants/layout.ts
+++ b/apps/client/src/shared/constants/layout.ts
@@ -11,4 +11,6 @@ export const LAYOUT_HEIGHT = {
   DETAIL_HEADER: '4.4rem',
   /** 글로벌 + 페이지 헤더 스택. */
   HEADERS_STACKED: '9.8rem',
+  /** 하단 탭바(BottomNavigation) 전체 높이 (버튼 콘텐츠 + safe-area 하단 패딩). */
+  BOTTOM_NAVIGATION: 'calc(5.8rem + max(2rem, env(safe-area-inset-bottom)))',
 } as const;


### PR DESCRIPTION
## 📌 Summary

하단 탭바 도입(#866) 이후 생긴 레이아웃 보정이에요.

## 📚 Tasks

- **홈**: 세미헤더 제거분(4.4rem)만큼 헤더↔포스터 캐러셀 간격 축소 (`marginTop 8→3.6rem`, 섹션 `56.4→52rem`)
- **셋리스트 준비중 페이지**: 바텀탭 높이를 빼지 않아 생기던 스크롤·중앙정렬 틀어짐 수정 (`AppSafeArea` subtract에 헤더+바텀탭 반영)
- 바텀탭 높이를 `LAYOUT_HEIGHT.BOTTOM_NAVIGATION` 공유 상수로 추출 (spacer와 단일 소스)
